### PR TITLE
Account for Basics when inserting foils

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -163,7 +163,8 @@ function toPack(code) {
       }
     }
   }
-  if (_.rand(6) < 1 && !(foilCard) && !(masterpiece)) {
+  if (_.rand(7) < 1 && !(foilCard) && !(masterpiece)) {
+    // http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/768235-what-are-current-pack-odds-including-foils
     size = size - 1
     foilCard = _.choose(1, pickFoil(set))
     pack.push(foilCard[0])


### PR DESCRIPTION
According to [this article](http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/768235-what-are-current-pack-odds-including-foils) foil basics occur at a rate of approx 2/15. We'll discard those 2/15 and end up with 1/6.92 or approx 1/7 odds of getting a foil other than a basic land.

Closes #8