### PR TITLE
Close #52 - Managing Doublefaced cards

### DIFF
--- a/public/src/components/cols.js
+++ b/public/src/components/cols.js
@@ -5,21 +5,19 @@ let d = React.DOM
 export default React.createClass({
   getInitialState() {
     return {
-      className: 'right'
+      className: 'right',
     }
   },
   render() {
     let zones = this.props.zones.map(this.zone)
-    let img = this.state.url && d.img({
-      className: this.state.className,
-      id: 'img',
-      onMouseEnter: this.enter.bind(this, this.state.url),
-      src: this.state.url
+    const img = this.state.card && React.createElement(ImageHelper, {
+      card,   
+      className 
     })
-    return d.div({}, zones, img)
+    return d.div({}, zones, this.state.img)
   },
 
-  enter(url, e) {
+  enter(card, e) {
     let {offsetLeft} = e.target
     let {clientWidth} = document.documentElement
 
@@ -30,7 +28,7 @@ export default React.createClass({
       ? 'left'
       : 'right'
 
-    this.setState({ url, className })
+    this.setState({ card, className })
   },
   zone(zoneName) {
     let zone = getZone(zoneName)
@@ -41,7 +39,8 @@ export default React.createClass({
       let items = zone[key].map(card =>
         d.div({
           onClick: App._emit('click', zoneName, card.name),
-          onMouseOver: this.enter.bind(this, card.url)
+          onMouseEnter: this.enter.bind(this, card),
+          onMouseLeave: () => { this.setState({ card: false })}
         }, d.img({ src: card.url, alt: card.name }))
       )
 
@@ -54,5 +53,29 @@ export default React.createClass({
     return d.div({ className: 'zone' },
       d.h1({}, `${zoneName} ${sum}`),
       cols)
+  }
+})
+
+const ImageHelper = React.createClass({
+  render() {
+    if(this.props.card.isDoubleFaced) {
+      return d.div({
+        className: this.props.className,
+        id: 'img',
+      },
+      d.img({
+        src:this.props.card.url,
+      }),
+      d.img({
+        src:this.props.card.flippedCardURL,
+      })
+      )
+    }
+
+    return d.img({
+      className: this.props.className,
+      id: 'img',
+      src: this.props.card.url,
+    })
   }
 })

--- a/public/src/components/cols.js
+++ b/public/src/components/cols.js
@@ -11,8 +11,8 @@ export default React.createClass({
   render() {
     let zones = this.props.zones.map(this.zone)
     const img = this.state.card && React.createElement(ImageHelper, {
-      card,   
-      className 
+      card: this.state.card,   
+      className: this.state.className 
     })
     return d.div({}, zones, img)
   },
@@ -39,7 +39,7 @@ export default React.createClass({
       let items = zone[key].map(card =>
         d.div({
           onClick: App._emit('click', zoneName, card.name),
-          onMouseEnter: this.enter.bind(this, card),
+          onMouseOver: this.enter.bind(this, card),
           onMouseLeave: () => { this.setState({ card: false })}
         }, d.img({ src: card.url, alt: card.name }))
       )
@@ -61,12 +61,14 @@ const ImageHelper = React.createClass({
     if(this.props.card.isDoubleFaced) {
       return d.div({
         className: this.props.className,
-        id: 'img',
+        id: 'doubleimg',
       },
       d.img({
+        className: "card",
         src:this.props.card.url,
       }),
       d.img({
+        className: "card",
         src:this.props.card.flippedCardURL,
       })
       )

--- a/public/src/components/cols.js
+++ b/public/src/components/cols.js
@@ -5,7 +5,7 @@ let d = React.DOM
 export default React.createClass({
   getInitialState() {
     return {
-      className: 'right',
+      className: 'right'
     }
   },
   render() {
@@ -14,7 +14,7 @@ export default React.createClass({
       card,   
       className 
     })
-    return d.div({}, zones, this.state.img)
+    return d.div({}, zones, img)
   },
 
   enter(card, e) {

--- a/public/src/components/grid.js
+++ b/public/src/components/grid.js
@@ -19,20 +19,54 @@ function zone(zoneName) {
   let isAutopickable = card => zoneName === 'pack' && card.isAutopick
 
   let items = cards.map(card =>
-    d.span(
-      {
-        className: `card ${isAutopickable(card) ? 'autopick-card ' : ''} card ${card.foil ? 'foil-card ' : ''}`,
-        title: isAutopickable(card) ? 'This card will be automatically picked if your time expires.' : '',
-        onClick: App._emit('click', zoneName, card.name),
-      },
-      d.img({
-        src: card.url,
-        alt: card.name,
-      })))
-
+      React.createElement(Card, {
+        card: card,
+        isAutopick: isAutopickable(card),
+        zoneName:zoneName
+      })
+    )
   return d.div({ className: 'zone' },
     d.h1({}, Spaced(
       d.span({}, zoneName),
       d.span({}, `${cards.length} ${zoneName === 'pack' ? ' /  ' + cards[0].packSize.toString() : ""} ${cards.length === 1 ? 'card' : 'cards' }`))),
     items)
 }
+
+const Card = React.createClass({
+  getInitialState() {
+    return {
+      card: this.props.card,
+      url: this.props.card.url
+    }
+  },
+  onMouseEnter() {
+    if(this.state.card.isDoubleFaced) {
+      this.setState({
+        url: this.state.card.flippedCardURL
+      })
+    }
+  },
+  onMouseLeave() {
+    this.setState({
+      url: this.state.card.url
+    })
+  },
+  render() {
+    if(this.props.card != this.state.card) {
+      this.state.card = this.props.card;
+      this.state.url = this.props.card.url
+    }
+    return d.span({
+      onMouseOver: this.onMouseEnter,
+      onMouseLeave: this.onMouseLeave,
+      className: `card ${this.props.isAutopick ? 'autopick-card ' : ''} card ${this.props.card.foil ? 'foil-card ' : ''}`,
+      title: this.props.isAutopick ? 'This card will be automatically picked if your time expires.' : '',
+      onClick: App._emit('click', this.props.zoneName, this.state.card.name),
+    },
+    d.img({
+      src: this.state.url,
+      alt: this.state.card.name,
+    })
+  )
+  }
+})

--- a/public/style.css
+++ b/public/style.css
@@ -244,6 +244,11 @@ input[type=button]:disabled:active, button:disabled:active {
   cursor: pointer;
 }
 
+#doubleimg {
+  height: 340px;
+  width: 480px;
+}
+
 .col {
   float: left;
   width: 180px;
@@ -374,15 +379,15 @@ input[type=button]:disabled:active, button:disabled:active {
   text-align: center;
 }
 
-#img {
+#img, #doubleimg {
   position: fixed;
   bottom: 0;
   z-index: 1;
 }
-#img.left {
+#img.left, #doubleimg.left {
   left: 0;
 }
-#img.right {
+#img.right, #doubleimg.right {
   right: 0;
 }
 

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -376,8 +376,18 @@ function doSet(rawSet, code) {
       Cards[lc].sets[code] = card.sets[code]
     else
       Cards[lc] = card
-  }
 
+    //Taking care of DoubleFaced Cards URL
+    if(card.isDoubleFaced) {
+      rawSet.cards.some(x=> {
+        if(x.name == card.names[1]) {
+          card.flippedCardURL=`http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=${x.multiverseid}&type=card`
+          return true
+        }
+      })
+    }
+  }
+  
   if (!rawSet.booster)
     return
 
@@ -433,7 +443,10 @@ function doCard(rawCard, cards, code, set) {
       [code]: { rarity,
         url: picUrl
       }
-    }
+    },
+    layout: rawCard.layout,
+    isDoubleFaced: rawCard.layout == "double-faced",
+    names: rawCard.names
   }
 
   set[rarity].push(name.toLowerCase())


### PR DESCRIPTION
This pull adds 
1. show flipped face during mouseOver on doublefaced cards
2. show the two faces of double-faced cards on main and and side zones, thanks to imageHelper popup.