### PR TITLE
Add padding - visually separate card piles

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -252,6 +252,7 @@ input[type=button]:disabled:active, button:disabled:active {
 .col {
   float: left;
   width: 180px;
+  padding: 1px;
 }
 
 .col img {


### PR DESCRIPTION
fixes #59

Screenshot from HerveH44's Heroku instance at https://beta-dr4ft.herokuapp.com/ with his refactor branch:
![padding](https://user-images.githubusercontent.com/9874850/34534894-4ff46cdc-f0c0-11e7-9fc5-203c834a9e6f.png)

---

Taken from https://github.com/HerveH44/dr4ft/commit/96d0122c1f67d4828cce602e9bf9bb160d350f6d
(as part of this branch: https://github.com/HerveH44/dr4ft/tree/refactor_frontend)

originally by @HerveH44
  