### PR TITLE
Optimize webpack bundling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
   </div>
   <script type="text/javascript" src="lib/engine.io.js"></script>
   <script type="text/javascript" src="lib/react.js"></script>
+  <script type="text/javascript" src="lib/react-dom.js"></script>
   <script type="text/javascript" src="lib/app.js"></script>
 </body>
 </html>

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -18,6 +18,8 @@ if (!fs.existsSync(libDir)) {
   fs.mkdirSync(libDir);
   fs.symlinkSync("../../node_modules/utils/utils.js", `${libDir}/utils.js`)
   fs.symlinkSync("../../node_modules/ee/ee.js", `${libDir}/ee.js`)
+  fs.symlinkSync("../../node_modules/react/umd/react.production.min.js", `${libDir}/react.js`)
+  fs.symlinkSync("../../node_modules/react-dom/umd/react-dom.production.min.js", `${libDir}/react-dom.js`)
   fs.createReadStream('node_modules/engine.io-client/engine.io.js').pipe(fs.createWriteStream(`${libDir}/engine.io.js`));
   fs.createReadStream('node_modules/normalize.css/normalize.css').pipe(fs.createWriteStream(`${libDir}/normalize.css`));
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,7 @@ module.exports = {
   devtool: "cheap-eval-source-map",
   context: __dirname,
   entry: {
-    app: "./public/src/init.js",
-    react: ["react", "react-dom"]
+    app: "./public/src/init.js"
   },
   output: {
     path: path.join(__dirname, "./public/lib"),
@@ -52,5 +51,9 @@ module.exports = {
         loader: "url-loader"
       }
     ]
+  },
+  externals: {
+    'react': 'React',
+    'react-dom': 'ReactDOM'
   }
 };


### PR DESCRIPTION
Hi, 

I witnessed that the bundles (react and app) are atrouciously large (1.8MB and 2.2MB). After checking, I chose to go with a simpler route: we exclude react bundling but take it from the node_modules sources, just like we actually do with other libs (utils.js, ee.js, engine.io ...). It reduced the total from 4 MB to ... 500kB !! The app bundle is now 390k and react and react-dom is around 110k total. I guess we could put up some development / production differences (like uglify, or use of react development bundles which are bigger but shouts in the console any possible code improvement). But right now, I feel pretty happy with this setup.

Summary:

- Before **4MB**
- After **500KB**

As a nice side-effect, you can see the PR deployed on heroku and see the difference https://beta-dr4ft-pr-102.herokuapp.com/ and the other PR https://beta-dr4ft-pr-96.herokuapp.com/
Hervé