### PR TITLE
Dev: add Dominaria support.  Closes #118

### DIFF
--- a/public/src/sets.js
+++ b/public/src/sets.js
@@ -1,5 +1,6 @@
 export default {
   expansion: {
+    "Dominaria": "DOM",
     "Rivals of Ixalan": "RIX",
     "Ixalan": "XLN",
     "Hour of Devastation": "HOU",

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -403,7 +403,7 @@ function doSet(rawSet, code) {
 }
 
 function doCard(rawCard, cards, code, set) {
-  var {name, number, mciNumber = "", layout, names, cmc, color, colors, types, text, manaCost, url, multiverseid} = rawCard
+  var {name, number, mciNumber = "", layout, names, cmc, color, colors, types, supertypes, text, manaCost, url, multiverseid} = rawCard
   var rarity = rawCard.rarity.split(' ')[0].toLowerCase();
 
   if (/^basic/i.test(rarity))
@@ -454,7 +454,8 @@ function doCard(rawCard, cards, code, set) {
     },
     layout: layout,
     isDoubleFaced: /^double-faced$/i.test(layout),
-    names: names
+    names: names,
+    supertypes: supertypes || []
   }
 
   set[rarity].push(name.toLowerCase())

--- a/src/pool.js
+++ b/src/pool.js
@@ -133,6 +133,7 @@ function toPack(code) {
         special = special.common
       break
     case 'DOM':
+      // http://markrosewater.tumblr.com/post/172581930278/do-the-legendaries-that-appear-in-the-legendary
       // Every booster must contain a legendary creature either as uncommon or rare
       let hasLegendaryCreature = false;
       const isLegendaryCreature = cardName => {

--- a/src/pool.js
+++ b/src/pool.js
@@ -132,14 +132,14 @@ function toPack(code) {
     else
       special = special.common;
     break;
-  case 'DOM':
+  case "DOM":
     // http://markrosewater.tumblr.com/post/172581930278/do-the-legendaries-that-appear-in-the-legendary
     // Every booster must contain a legendary creature either as uncommon or rare
     let hasLegendaryCreature = false;
     const isLegendaryCreature = cardName => {
       const card = Cards[cardName];
       return card.supertypes.includes("Legendary") && card.type === "Creature";
-    }
+    };
 
     pack.some(cardName => {
       return hasLegendaryCreature = isLegendaryCreature(cardName);
@@ -155,20 +155,20 @@ function toPack(code) {
         // Uncommon slot
         var packIndex = 0;
         var pool = uncommon;
-        }
+      }
       const legendaryCreatures = pool.filter(isLegendaryCreature);
       pack[packIndex] = _.choose(1, legendaryCreatures);
     }
     break;
-  case 'M19':
+  case "M19":
     //http://wizardsmagic.tumblr.com/post/175584204911/core-set-2019-packs-basic-lands-and-upcoming
     // 5/12 of times -> dual-land
     // 7/12 of times -> basic land
-    const dualLands = common.filter(cardName => Cards[cardName].type === "Land")
-    common = common.filter(cardName => !dualLands.includes(cardName)) //delete dualLands from possible choice as common slot
+    const dualLands = common.filter(cardName => Cards[cardName].type === "Land");
+    common = common.filter(cardName => !dualLands.includes(cardName)); //delete dualLands from possible choice as common slot
     const isDualLand = _.rand(12) < 6;
-    const land = _.choose(1, isDualLand ? dualLands : basic)
-    pack.push(land)
+    const land = _.choose(1, isDualLand ? dualLands : basic);
+    pack.push(land);
     break;
   }
   var masterpiece = "";

--- a/src/pool.js
+++ b/src/pool.js
@@ -132,6 +132,33 @@ function toPack(code) {
       else
         special = special.common
       break
+    case 'DOM':
+      // Every booster must contain a legendary creature either as uncommon or rare
+      let hasLegendaryCreature = false;
+      const isLegendaryCreature = cardName => {
+        const card = Cards[cardName];
+        return card.supertypes.includes("Legendary") && card.type === "Creature";
+      }
+
+      pack.some(cardName => {
+        return hasLegendaryCreature = isLegendaryCreature(cardName);
+      });
+
+      if (!hasLegendaryCreature) {
+        // Choose to replace an uncommon or rare slot
+        if (_.rand(4) === 0) {
+          var packIndex = 3;
+          var isMythic = mythic.includes(pack[packIndex]);
+          var pool = isMythic ? mythic : rare;
+        } else {
+          // Uncommon slot
+          var packIndex = 0;
+          var pool = uncommon;
+        }
+        const legendaryCreatures = pool.filter(isLegendaryCreature);
+        pack[packIndex] = _.choose(1, legendaryCreatures);
+      }
+      break;
   }
   var masterpiece = ''
   if (special) {


### PR DESCRIPTION
Support dominaria constraint for Legendary creatures following rule : 

Each booster is arranged so one of the uncommon or rare/mythic rare slots is filled with a legendary creature.

http://markrosewater.tumblr.com/post/172581930278/do-the-legendaries-that-appear-in-the-legendary