### PR TITLE
CI: enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       node_js: node
       cache:
         directories:
-        - node_modules
+          - node_modules
       install:
         - npm install
       script: skip    # no tests configured yet

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:    # needed as empty for allow_failure on env to work, see https://docs.tra
 
 matrix:
   include:
-    - name: Install Node.js app on newest Node.js
+    - name: Install Node.js app (newest Node.js)
       language: node_js
       node_js: node
       cache:
@@ -13,7 +13,7 @@ matrix:
       install:
         - npm install
       script: skip
-    - name: Install Node.js app on newest Node.js LTS
+    - name: Install Node.js app (newest Node.js LTS)
       language: node_js
       node_js: lts/*
       cache:
@@ -22,6 +22,21 @@ matrix:
       install:
         - npm install
       script: skip
+    - name: Build and run Docker image (newest Docker)
+      language: generic
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      services:
+        - docker
+      script:
+        - docker --version
+        - docker build --tag dr4ft-app .
+        - docker run -dp 1337:1337 dr4ft-app
+        - docker ps -a
+      after_script:
+        - docker images
     - name: ESLint
       language: node_js
       node_js: node

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,23 @@ matrix:
           - node_modules
       install:
         - npm install
-      script: skip    # no tests configured yet
+      script: skip    # skips default 'npm test' command in 'script' step; no tests configured yet
 
-    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
-      language: generic
-      addons:
-        apt:
-          packages:
-            - docker-ce
-      services:
-        - docker
-      script:
-        - docker --version
-        - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
-        - docker run -dp 1337:1337 dr4ft-app
-        - docker ps -a
-      after_script:
-        - docker images
+#    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
+#      language: generic
+#      addons:
+#        apt:
+#          packages:
+#            - docker-ce
+#      services:
+#        - docker
+#      script:
+#        - docker --version
+#        - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
+#        - docker run -dp 1337:1337 dr4ft-app
+#        - docker ps -a
+#      after_script:
+#        - docker images
 
 #-------------------------------------------------
 #nodejs + docker in stages setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 #normal matrix.include setup
+
+env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+
 matrix:
   include:
     - name: Install Node.js app on newest Node.js
@@ -22,11 +25,13 @@ matrix:
     - name: ESLint Check
       language: node_js
       node_js: node
+      env: allowed_to_fail
       install: skip
       script:
         - npm test
   allow_failures:
-    - name: ESLint
+    - env: allowed_to_fail
+  fast_finish: true
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
 #      language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ matrix:
       language: node_js
       node_js: node
       env: allowed_to_fail
-      cache:
-        directories:
-          - node_modules
-      install: skip
+      install:
+        - npm install -g eslint
       script:
         - npm test
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
           - node_modules
       install:
         - npm install
-      script: skip    # skips default 'npm test' command in 'script' step; no tests configured yet
+      script:
+        - npm test
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
 #      language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,103 @@
+#normal matrix setup
+language: node_js
+
+node_js:
+  - node     # latest stable Node.js release
+#  - lts/*    # latest LTS Node.js release
+
+install:
+  - npm install
+
+#cache:
+#  directories:
+#    - "node_modules"
+
+matrix:
+  include:
+#    - name: Build and run Docker image (with 'Dockerfile'), default Docker
+#      language: generic
+#      services:
+#        - docker
+#      script:
+#        - docker --version
+#        - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
+#        - docker run -dp 1337:1337 dr4ft-app
+#        - docker ps -a
+#      after_script:
+#        - docker images
+    - name: Build and run Docker image (with 'Dockerfile'), newest Docker
+      language: generic
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      services:
+        - docker
+      script:
+        - docker --version
+        - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
+        - docker run -dp 1337:1337 dr4ft-app
+        - docker ps -a
+      after_script:
+        - docker images
+
+#nodejs + docker in stages setup
+#jobs:
+#  include:
+#  - stage: Tests
+#    name: Install (on latest Node.js)
+#    language: node_js
+#    node_js:
+#       - node     # latest stable Node.js release
+#    #   - lts/*    # latest LTS Node.js release
+#    install:
+#      - npm install
+#    # script:
+#    #   - npm start
+#    # after_script:
+#    #    - npm test
+#    # cache:
+#    #    directories:
+#    #      - "node_modules"
+#  - stage: Tests
+#    name: Install (on latest Node.js LTS)
+#    language: node_js
+#    node_js:
+#       - lts/*    # latest LTS Node.js release
+#    install:
+#      - npm install
+#    # script:
+#    #   - npm start
+#    # after_script:
+#    #    - npm test
+#    # cache:
+#    #    directories:
+#    #      - "node_modules"
+#  - stage: Tests
+#    name: Build and run Docker image (with 'Dockerfile')
+#    language: generic
+#    services:
+#      - docker
+#    script:
+#      - docker --version
+#      - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
+#      - docker run -dp 1337:1337 dr4ft-app
+#      - docker ps -a
+#    after_script:
+#      - docker images
+#  - stage: Tests
+#    name: Build and run Docker image (with 'Dockerfile'), newest Docker
+#    language: generic
+#    addons:
+#      apt:
+#        packages:
+#          - docker-ce
+#    services:
+#      - docker
+#    script:
+#      - docker --version
+#      - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
+#      - docker run -dp 1337:1337 dr4ft-app
+#      - docker ps -a
+#    after_script:
+#      - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 #normal matrix.include setup
-name:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+
+#env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+name:
 
 matrix:
   include:
@@ -47,6 +49,7 @@ matrix:
         - npm test
   allow_failures:
     - name: ESLint
+#    - env: eslint
   fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
@@ -131,7 +134,7 @@ matrix:
 #  email: false
 #  webhooks:
 #    urls:
-#      - put dr4ft gitter hook url here
+#      - dr4ft gitter url here
 #    on_success: change
 #    on_failure: change
 #    on_start: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ matrix:
     - name: Build and run Node.js app on newest Node.js
       language: node_js
       node_js: node
-#      cache:
-#        directories:
-#        - node_modules
+      cache:
+        directories:
+        - node_modules
       install:
         - npm install
+      script: skip    # no tests configured yet
 
     - name: Build and run Docker image (with 'Dockerfile') on newest Docker
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 #normal matrix.include setup
-
-#env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
-name:
+name:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
 
 matrix:
   include:
@@ -49,7 +47,6 @@ matrix:
         - npm test
   allow_failures:
     - name: ESLint
-#    - env: eslint
   fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
@@ -134,7 +131,7 @@ matrix:
 #  email: false
 #  webhooks:
 #    urls:
-#      - dr4ft gitter url here
+#      - put dr4ft gitter hook url here
 #    on_success: change
 #    on_failure: change
 #    on_start: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 #normal matrix.include setup
 
-#env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
-name:
+env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
 
 matrix:
   include:
@@ -48,8 +47,7 @@ matrix:
       script:
         - npm test
   allow_failures:
-    - name: ESLint
-#    - env: eslint
+    - env: eslint
   fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - npm test
   allow_failures:
     - env: eslint
-  fast_finish: true
+  fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
 #      language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,3 +88,14 @@ matrix:
 #      - docker ps -a
 #    after_script:
 #      - docker images
+
+#notifications:
+#  email: false
+#  webhooks:
+#    urls:
+#      - dr4ft gitter url here
+#    on_success: change
+#    on_failure: change
+#    on_start: never
+#    on_cancel: change
+#    on_error: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,16 @@
-#normal matrix setup
-language: node_js
-
-node_js:
-  - node     # latest stable Node.js release
-#  - lts/*    # latest LTS Node.js release
-
-install:
-  - npm install
-
-#cache:
-#  directories:
-#    - "node_modules"
-
+#normal matrix.include setup
 matrix:
   include:
-#    - name: Build and run Docker image (with 'Dockerfile'), default Docker
-#      language: generic
-#      services:
-#        - docker
-#      script:
-#        - docker --version
-#        - docker build --tag dr4ft-app .    # builds from the Dockerfile in repo root
-#        - docker run -dp 1337:1337 dr4ft-app
-#        - docker ps -a
-#      after_script:
-#        - docker images
-    - name: Build and run Docker image (with 'Dockerfile'), newest Docker
+    - name: Build and run Node.js app on newest Node.js
+      language: node_js
+#     node_js: node
+#      cache:
+#        directories:
+#        - node_modules
+      install:
+        - npm install
+
+    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
       language: generic
       addons:
         apt:
@@ -41,6 +26,7 @@ matrix:
       after_script:
         - docker images
 
+#-------------------------------------------------
 #nodejs + docker in stages setup
 #jobs:
 #  include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 #normal matrix.include setup
 matrix:
   include:
-    - name: Build and run Node.js app on newest Node.js
+    - name: Install Node.js app on newest Node.js
       language: node_js
       node_js: node
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 #normal matrix.include setup
-
-env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+env:    # key needs exist on top level for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
 
 matrix:
   include:
@@ -132,7 +131,7 @@ matrix:
 #  email: false
 #  webhooks:
 #    urls:
-#      - dr4ft gitter url here
+#      - put dr4ft gitter hook url here
 #    on_success: change
 #    on_failure: change
 #    on_start: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
     - name: Build and run Node.js app on newest Node.js
       language: node_js
-#     node_js: node
+      node_js: node
 #      cache:
 #        directories:
 #        - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
       language: node_js
       node_js: node
       env: allowed_to_fail
+      cache:
+        directories:
+          - node_modules
       install: skip
       script:
         - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 #normal matrix.include setup
 
-env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+#env:    # needed as empty for allow_failure on env to work, see https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures
+name:
 
 matrix:
   include:
@@ -47,7 +48,8 @@ matrix:
       script:
         - npm test
   allow_failures:
-    - env: eslint
+    - name: ESLint
+#    - env: eslint
   fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ matrix:
       install:
         - npm install
       script: skip
-    - name: ESLint Check
+    - name: ESLint
       language: node_js
       node_js: node
       env: allowed_to_fail
       install:
-        - npm install eslint --save-dev
+        - npm install -g eslint
+        - npm install -g eslint-plugin-react
       script:
         - npm test
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       node_js: node
       env: allowed_to_fail
       install:
-        - npm install -g eslint
+        - npm install eslint --save-dev
       script:
         - npm test
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ matrix:
     - name: ESLint
       language: node_js
       node_js: node
-      env: allowed_to_fail
+      env: eslint
       install:
         - npm install -g eslint
         - npm install -g eslint-plugin-react
       script:
         - npm test
   allow_failures:
-    - env: allowed_to_fail
+    - env: eslint
   fast_finish: true
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ matrix:
       script: skip
     - name: Build and run Docker image (newest Docker)
       language: generic
+      env: docker
+      services:
+        - docker
       addons:
         apt:
           packages:
             - docker-ce
-      services:
-        - docker
       script:
         - docker --version
         - docker build --tag dr4ft-app .
@@ -47,6 +48,7 @@ matrix:
         - npm test
   allow_failures:
     - env: eslint
+    - env: docker
   fast_finish: true    # mark build as failed/passed as soon as possible, don't wait for the allow_failures build to finish! See https://docs.travis-ci.com/user/customizing-the-build#fast-finishing
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,24 @@ matrix:
           - node_modules
       install:
         - npm install
+      script: skip
+    - name: Install Node.js app on newest Node.js LTS
+      language: node_js
+      node_js: lts/*
+      cache:
+        directories:
+          - node_modules
+      install:
+        - npm install
+      script: skip
+    - name: ESLint Check
+      language: node_js
+      node_js: node
+      install: skip
       script:
         - npm test
+  allow_failures:
+    - name: ESLint
 
 #    - name: Build and run Docker image (with 'Dockerfile') on newest Docker
 #      language: generic

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev-server": "webpack-dev-server --hot --progress --inline --output-path /lib/app.js --entry ./public/src/init.js --output-filename ./lib/app.js",
     "server": "webpack-dev-server --open --inline --hot",
     "postinstall": "node scripts/postinstall && node src/make/cards && node src/make/score && webpack"
+    "pretest": "eslint --ignore-path .gitignore ."
   },
   "dependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "watch": "webpack --watch -d --display-error-details",
     "dev-server": "webpack-dev-server --hot --progress --inline --output-path /lib/app.js --entry ./public/src/init.js --output-filename ./lib/app.js",
     "server": "webpack-dev-server --open --inline --hot",
-    "postinstall": "node scripts/postinstall && node src/make/cards && node src/make/score && webpack"
+    "postinstall": "node scripts/postinstall && node src/make/cards && node src/make/score && webpack",
     "pretest": "eslint --ignore-path .gitignore ."
   },
   "dependencies": {


### PR DESCRIPTION
First version of working Travis CI:
- Install test on Node.js, which should had spotted the need for https://github.com/dr4fters/dr4ft/pull/145.
- Added ESLint check
- Added Node.js LTS
- Added check for Dockerfile

New GitHub Checks API in action: https://github.com/dr4fters/dr4ft/pull/150/checks

Note, that there is currently still a bug with the new Travis App for GitHub and builds are reported and shown twice, tracked in https://github.com/travis-ci/travis-ci/issues/9618:
>Yes, right now we're reporting the status two times per build triggered, one for the previous commit statuses and another one via GitHub Checks.
>
>We are aware of this issue, and we are working to clean it up in the coming weeks.
>
>Thank you for your understanding and patience.

---

This PR should be merged before #146 
