### PR TITLE
Repo cleanup: Unified dependency linking to our own forks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8289,8 +8289,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils": {
-      "version": "git://github.com/arxanas/utils.git#880a017d5b5f4a2b593c38232b7ade3c1bfef476",
-      "from": "git://github.com/arxanas/utils.git#880a017d5b5f4a2b593c38232b7ade3c1bfef476"
+      "version": "git://github.com/dr4fters/utils.git#880a017d5b5f4a2b593c38232b7ade3c1bfef476",
+      "from": "git://github.com/dr4fters/utils.git#880a017d5b5f4a2b593c38232b7ade3c1bfef476"
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2542,8 +2542,8 @@
       }
     },
     "ee": {
-      "version": "git://github.com/aeosynth/ee.git#94181581209514890a6e130e756663f65e19be53",
-      "from": "git://github.com/aeosynth/ee.git"
+      "version": "git://github.com/dr4fters/ee.git#94181581209514890a6e130e756663f65e19be53",
+      "from": "git://github.com/dr4fters/ee.git"
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
-    "ee": "git://github.com/dr4fters/ee.git",
+    "ee": "git://github.com/aeosynth/ee.git",
     "engine.io": "^3.2.0",
     "engine.io-client": "^3.2.1",
     "jsonfile": "^4.0.0",
@@ -44,7 +44,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "send": "^0.16.2",
-    "utils": "git://github.com/dr4fters/utils.git",
+    "utils": "git://github.com/arxanas/utils.git",
     "webpack": "^4.16.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
-    "ee": "git://github.com/aeosynth/ee.git",
+    "ee": "git://github.com/dr4fters/ee.git",
     "engine.io": "^3.2.0",
     "engine.io-client": "^3.2.1",
     "jsonfile": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
-    "ee": "git://github.com/aeosynth/ee.git",
+    "ee": "git://github.com/dr4fters/ee.git",
     "engine.io": "^3.2.0",
     "engine.io-client": "^3.2.1",
     "jsonfile": "^4.0.0",
@@ -44,7 +44,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "send": "^0.16.2",
-    "utils": "git://github.com/arxanas/utils.git",
+    "utils": "git://github.com/dr4fters/utils.git",
     "webpack": "^4.16.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "send": "^0.16.2",
-    "utils": "git://github.com/arxanas/utils.git",
+    "utils": "git://github.com/dr4fters/utils.git",
     "webpack": "^4.16.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Realized the mismatch and non-uniform linking here: https://david-dm.org/dr4fters/dr4ft

Now only links to our own forks, so we are no longer dependent on repos we don't control.