### PR TITLE
Bypass browser cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data
 public/out
 public/lib
 public/src/config.js
+public/index.html
 
 config.client.js
 config.server.js

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "dev-server": "webpack-dev-server --hot --progress --inline --output-path /lib/app.js --entry ./public/src/init.js --output-filename ./lib/app.js",
     "server": "webpack-dev-server --open --inline --hot",
     "postinstall": "node scripts/postinstall && node src/make/cards && node src/make/score && webpack",
-    "pretest": "eslint --ignore-path .gitignore ."
+    "pretest": "eslint --ignore-path .gitignore .",
+    "build": "NODE_ENV=production webpack -p --progress --colors"
   },
   "dependencies": {
     "babel-cli": "^6.26.0",
@@ -37,6 +38,7 @@
     "ee": "git://github.com/dr4fters/ee.git",
     "engine.io": "^3.2.0",
     "engine.io-client": "^3.2.1",
+    "html-webpack-plugin": "3.2.0",
     "jsonfile": "^4.0.0",
     "log-timestamp": "^0.2.1",
     "node-fetch": "^2.2.0",

--- a/public/index.html.tpl
+++ b/public/index.html.tpl
@@ -23,6 +23,5 @@
   <script type="text/javascript" src="lib/engine.io.js"></script>
   <script type="text/javascript" src="lib/react.js"></script>
   <script type="text/javascript" src="lib/react-dom.js"></script>
-  <script type="text/javascript" src="lib/app.js"></script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const webpack = require("webpack");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   devtool: "cheap-eval-source-map",
@@ -9,8 +10,8 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, "./public/lib"),
-    filename: "[name].js",
-    publicPath: "/"
+    filename: "[name]-[hash].js",
+    publicPath: "lib"
   },
   devServer: {
     contentBase: path.join(__dirname, "public"),
@@ -21,6 +22,10 @@ module.exports = {
   },
   plugins: [
     new webpack.NamedModulesPlugin(),
+    new HtmlWebpackPlugin({
+      template: './public/index.html.tpl',
+      filename: __dirname + '/public/index.html'
+    })
   ],
   resolve: {
     extensions: [".js", ".jsx", ".css", ".less"],


### PR DESCRIPTION
As #185 showed, people have problems when we update the app, because their browser caches the javascript and can creates problem. 

I updated the webpack configuration to create everytime a new app bundle with an hash based on the app file content. Doing so, the browser will think it has to download a new file every time we update our websites and it will no longer keep old cache.

