### PR TITLE
update known pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Found **bugs** or have **feature requests**? Feel free to [open an issue](https:
 It supports all their features, and many more.
 
 #### Known pages running this code:
- - [dr4ft.com](http://dr4ft.com)
- - [dr4ft.info](https://www.dr4ft.info/)
+ - [dr4ft.info](https://www.dr4ft.info)
+ - [dr4ft.com](http://www.dr4ft.com)
 
 
 


### PR DESCRIPTION
It looks like .com is down currently.

Any news if @dev-id is doing an update etc. or if the page is gone?

---

@ZeldaZach could you update the dr4ft page link in the repo to be https please?