### PR TITLE
War of the spark: filter guildgates from normal draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5828,9 +5828,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/src/_.js
+++ b/src/_.js
@@ -58,12 +58,5 @@ module.exports = {
   },
   rand(n) {
     return Math.floor(Math.random() * n);
-  },
-  chooseOne(arr) {
-    if(!arr || arr.length == 0) {
-      throw new Error("the array can't be null or empty");
-    }
-
-    return arr[Math.floor(Math.random() * arr.length)];
   }
 };

--- a/src/_.js
+++ b/src/_.js
@@ -58,5 +58,12 @@ module.exports = {
   },
   rand(n) {
     return Math.floor(Math.random() * n);
+  },
+  chooseOne(arr) {
+    if(!arr || arr.length == 0) {
+      throw new Error("the array can't be null or empty");
+    }
+
+    return arr[Math.floor(Math.random() * arr.length)];
   }
 };

--- a/src/make/allsets.js
+++ b/src/make/allsets.js
@@ -9,7 +9,7 @@ const versionURL = "https://mtgjson.com/json/version.json";
 const setsVersion = "data/version.json";
 
 const isVersionNewer = (remoteVer, currentVer) => (
-  Number(remoteVer.version.replace(/\./g, "")) > Number(currentVer.version.replace(/\./g, ""))
+  Number(remoteVer.date.replace(/-/g, "")) > Number(currentVer.date.replace(/-/g, ""))
 );
 
 const isVersionUpToDate = () => (

--- a/src/pool.js
+++ b/src/pool.js
@@ -185,6 +185,10 @@ function toPack(code) {
     break;
   }
   case "WAR": {
+    //No Guildgates
+    const guildGates = common.filter(cardName => getCards()[cardName].type === "Land" && getCards()[cardName].sets[code].rarity == "common");
+    common = common.filter(cardName => !guildGates.includes(cardName)); //delete guildGates from possible choice as common slot
+
     // https://magic.wizards.com/en/articles/archive/feature/closer-look-stained-glass-planeswalkers-2019-03-08
     // Every booster must contain a planeswalker either as uncommon or rare
     const isPlaneswalker = cardName => {
@@ -192,18 +196,30 @@ function toPack(code) {
       return card.type === "Planeswalker";
     };
 
-    hasPlaneswalker = pack.some(cardName => isPlaneswalker(cardName));
+    const packIndex = _.rand(4);
+    const isRareAMythic = mythic.includes(pack[packIndex]);
+    const rarePool = isRareAMythic ? mythic : rare;
+    const uncosWithoutPws = uncommon.filter(card => !isPlaneswalker(card));
+    const raresWithoutPws = rarePool.filter(card => !isPlaneswalker(card));
+    const raresWithPws = rarePool.filter(isPlaneswalker);
+    const uncosWithPws = uncommon.filter(isPlaneswalker);
 
-    if (!hasPlaneswalker) {
-      var packIndex = _.rand(4);
-      var pool = uncommon;
-      // Choose to replace an uncommon(default) or rare slot
-      if (packIndex === 3) {
-        var isMythic = mythic.includes(pack[packIndex]);
-        pool = isMythic ? mythic : rare;
-      }
-      const planeswalkers = pool.filter(isPlaneswalker);
-      pack[packIndex] = _.choose(1, planeswalkers);
+    // Checking which card will be a PW
+    // 0-2: should be an Uncommon
+    // 3: should be the mythic/rare
+    switch(packIndex) {
+    case 3: 
+      pack = [].concat(
+        _.choose(3, uncosWithoutPws),
+        _.choose(1, raresWithPws)
+      );
+      break;
+    
+    default:
+      // Set rare slot to Non-Pw
+      pack[3]  = raresWithoutPws[_.rand(raresWithoutPws.length)];
+      // Set one unco with Pws
+      pack.splice(0, 3, _.chooseOne(uncosWithPws), ..._.choose(2, uncosWithoutPws));
     }
     break;
   }

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -50,3 +50,49 @@ describe("Acceptance tests for Pool class", () => {
     });
   });
 });
+
+describe("Set tests for Pool class", () => {
+  describe("can make a WAR Pool", () => {
+    it("should return a pack of 14 cards", () => {
+      const got = Pool.DraftNormal({playersLength: 1, sets: ["WAR"]});
+      assert.equal(14, got[0].length);
+    });
+    it("should return a pack without guildgates", () => {
+      const got = Pool.DraftNormal({playersLength: 1, sets: new Array(20).fill("WAR")});
+      assert.equal(0, got[0].flat().filter(({type, rarity}) => type === "Land" && rarity == "common").length);
+    });
+    it("should return a pack with at least one planeswalker", () => {
+      const got = Pool.DraftNormal({playersLength: 1, sets: new Array(20).fill("WAR")});
+      got.forEach(pack => {
+        const numberOfPws = pack.filter(({type}) => type === "Planeswalker").length;
+        if (numberOfPws == 0) {
+          assert.fail("No Planeswalker were found in the pack");
+        }
+      });
+    });
+    it("should return a pack with at most one planeswalker", () => {
+      const got = Pool.DraftNormal({playersLength: 1, sets: new Array(20).fill("WAR")});
+      got.forEach(pack => {
+        const numberOfPws = pack.filter(({type}) => type === "Planeswalker").length;
+        if (numberOfPws > 1) {
+          const isPlaneswalker = card => {
+            return card.type === "Planeswalker";
+          };
+          const isRareOrMythic = ({rarity, foil}) => !foil && ["mythic", "rare"].includes(rarity);
+          const isUnco = ({rarity, foil}) => !foil && rarity === "uncommon";
+
+          const isRareAPw = pack.filter(isRareOrMythic).filter(isPlaneswalker).length > 0;
+          const isUncoAPw = pack.filter(isUnco).filter(isPlaneswalker).length > 0;
+          if (isRareAPw && isUncoAPw) {
+            assert.fail(`Too many Pws were found in the pack : ${numberOfPws}`);
+          }
+
+          if (!isRareAPw) {
+            assert.fail(`Too many Pws in uncommons were found in the pack : ${numberOfPws}`);
+          }
+        }
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Fixes #444 

Also:
- fix a minor npm audit problem
- add some tests for WAR (in test/pool.spec.js)
- use date instead of version to update AllSets.json (@ZeldaZach it seems that you bumped the date but not the version on MTGJson, am i correct? I feel that 4.3.2 had first the date 2019-3-30 and then 2019-04-20)