### PR TITLE
Add playable starter sets

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -44,10 +44,10 @@ const getPlayableSets = () => {
 
   const AllSets = getSets();
   for (let code in AllSets) {
-    const { type, name, releaseDate } = AllSets[code];
+    const { type, name, releaseDate, baseSetSize } = AllSets[code];
 
     //We do not want to play with these types of set (unplayable or lacking cards)
-    if (["masterpiece", "starter", "planechase", "commander"].includes(type)) {
+    if (["masterpiece", "planechase", "commander"].includes(type) || baseSetSize === 0) {
       continue;
     }
     

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -1,0 +1,12 @@
+/* eslint-env node, mocha */
+const assert = require("assert");
+const data = require("../src/data");
+
+describe("Acceptance tests for Data functions", () => {
+  describe("can find certain starter sets", () => {
+    it("find starter key in playable sets", () => {
+      const playableSets = data.getPlayableSets();
+      assert(playableSets["starter"]);
+    });
+  });
+});

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -7,7 +7,7 @@ describe("Acceptance tests for Pool class", () => {
     it("should return a sealed cube pool with length equal to player length", () => {
       const cubeList = new Array(720).fill("island");
       const playersLength = 8;
-      const got = Pool.SealedCubePool({ cubeList, playersLength });
+      const got = Pool.SealedCube({ cubeList, playersLength });
       assert.equal(playersLength, got.length);
     });
 
@@ -15,11 +15,11 @@ describe("Acceptance tests for Pool class", () => {
       const cubeList = new Array(720).fill("island");
       const playersLength = 8;
       const packsNumber = 3;
-      const got = Pool.DraftCubePool({ cubeList, playersLength, packsNumber });
+      const got = Pool.DraftCube({ cubeList, playersLength, packsNumber });
       assert.equal(playersLength*packsNumber, got.length);
     });
   });
-  
+
   describe("can make a normal pool", () => {
     it("should return a sealed pool with length equal to player length", () => {
       const sets = new Array(6).fill("M19");


### PR DESCRIPTION
closes #388 

I loosened the control on playable sets. After checking how starters can be divided as playable / non playable, I found that all playable starter sets have baseSetSize different of 0. 

