### PR TITLE
changes to mtgjson version display

### DIFF
--- a/public/src/lobby/Version.jsx
+++ b/public/src/lobby/Version.jsx
@@ -13,7 +13,7 @@ const Version = ({version, MTGJSONVersion}) => {
       <a href={`https://github.com/dr4fters/dr4ft/${getLink(version)}`}>
         {version}
       </a> (build {BUILD_DATE}) - Using <a href="https://www.mtgjson.com">MTGJSON</a> {" "}
-      card data version:{" "}
+      card data {" "}
       <a href={`https://mtgjson.com/changelog/#_${MTGJSONVersion.version.replace(/\./g, "-")}-${MTGJSONVersion.date}`}>
         v{MTGJSONVersion.version}
       </a> ({MTGJSONVersion.date})


### PR DESCRIPTION
Since MTGJSON uses semver with leading `v` it makes more sense to have this styling.

old: `Using MTGJSON card data version: v4.5.0-rebuild.5 (2019-09-14)`
new: `Using MTGJSON card data v4.5.0-rebuild.5 (2019-09-14)`

Screenshot:
![version](https://user-images.githubusercontent.com/9874850/65369666-44b94e00-dc50-11e9-8602-42a871407fd8.png)
