### PR TITLE
fix parse name of adventure cards

### DIFF
--- a/src/make/doSet.js
+++ b/src/make/doSet.js
@@ -72,7 +72,7 @@ function doCard({card, cards, rawSetCards, code, set, baseSetSize}) {
     return;
   }
 
-  if (/split|aftermath/i.test(layout))
+  if (/split|aftermath|adventure/i.test(layout))
     name = names.join(" // ");
 
   if (name in cards) {


### PR DESCRIPTION
I found out that ELD adventures cards' names could be simply parsed as we do for split and aftermath cards.

@tooomm could you test on Cockatrice as I don't have it.

closes #624