### PR TITLE
Hide unnecessary options in sealed mode from UI

### DIFF
--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -19,15 +19,17 @@ const GameSettings = () => (
               App.emit("side");
             }}/>
         </div>
+        {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />
-        </div>
+        </div>}
         <div>
           <Checkbox side="left" text="Column view" link="cols" />
         </div>
+        {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Hide your picks" link="hidepicks" />
-        </div>
+        </div>}
         <SortCards />
         <CardsImageQuality />
       </span>


### PR DESCRIPTION
closes #712 

Added a control on rendering of the following options:

- "Hide your picks"

- "Beep on new packs"
