### PR TITLE
More situational hide

### DIFF
--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -15,7 +15,6 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />
         </div>}
-        <div></div>
         {!App.state.isSealed &&
         <div>
           <Checkbox side="left" text="Add picks to sideboard"

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -11,15 +11,15 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Show chat" link="chat" />
         </div>
-        {!App.state.isSealed && App.state.didGameStart &&
-          <div>
-            <Checkbox side="left" text="Add picks to sideboard"
-              link="side"
-              onChange={(e) => {
-                App.save("side", e.target.checked);
-                App.emit("side");
-              }}/>
-          </div>}
+        {!App.state.isSealed &&
+        <div>
+          <Checkbox side="left" text="Add picks to sideboard"
+            link="side"
+            onChange={(e) => {
+              App.save("side", e.target.checked);
+              App.emit("side");
+            }}/>
+        </div>}
         {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -11,8 +11,7 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Show chat" link="chat" />
         </div>
-        {!App.state.isSealed &&
-          {!App.state.didGameStart &&
+        {!App.state.isSealed && App.state.didGameStart &&
           <div>
             <Checkbox side="left" text="Add picks to sideboard"
               link="side"
@@ -20,7 +19,7 @@ const GameSettings = () => (
                 App.save("side", e.target.checked);
                 App.emit("side");
               }}/>
-          </div>}}
+          </div>}
         {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -11,15 +11,16 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Show chat" link="chat" />
         </div>
-        {!App.state.isSealed && !App.state.didGameStart &&
-        <div>
-          <Checkbox side="left" text="Add picks to sideboard"
-            link="side"
-            onChange={(e) => {
-              App.save("side", e.target.checked);
-              App.emit("side");
-            }}/>
-        </div>}
+        {!App.state.isSealed &&
+          {!App.state.didGameStart &&
+          <div>
+            <Checkbox side="left" text="Add picks to sideboard"
+              link="side"
+              onChange={(e) => {
+                App.save("side", e.target.checked);
+                App.emit("side");
+              }}/>
+          </div>}}
         {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -11,6 +11,11 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Show chat" link="chat" />
         </div>
+        {!App.state.isSealed && 
+        <div>
+          <Checkbox side="left" text="Beep on new packs" link="beep" />
+        </div>}
+        <div></div>
         {!App.state.isSealed &&
         <div>
           <Checkbox side="left" text="Add picks to sideboard"
@@ -19,10 +24,6 @@ const GameSettings = () => (
               App.save("side", e.target.checked);
               App.emit("side");
             }}/>
-        </div>}
-        {!App.state.isSealed && 
-        <div>
-          <Checkbox side="left" text="Beep on new packs" link="beep" />
         </div>}
         <div>
           <Checkbox side="left" text="Column view" link="cols" />

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -11,6 +11,7 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Show chat" link="chat" />
         </div>
+        {!App.state.isSealed && !App.state.didGameStart &&
         <div>
           <Checkbox side="left" text="Add picks to sideboard"
             link="side"
@@ -18,7 +19,7 @@ const GameSettings = () => (
               App.save("side", e.target.checked);
               App.emit("side");
             }}/>
-        </div>
+        </div>}
         {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />


### PR DESCRIPTION
Expand on https://github.com/dr4fters/dr4ft/pull/717

I think it could still be useful to have this option displayed before a sealed game starts so that somebody could decide to "open his packs" in the sideboard to start building from there - move playable ones or his final cards to main deck, while throwing rubbish to the junk zone. Doing this manually takes a while.
But mostly this option is not needed.
But then the wording **picks** would not be precise still. (--> `Add cards/packs to sideboard`)

Played around a bit to have it check for sealed mode and if a game started without luck. :P