### PR TITLE
uniform wording in settings

### DIFF
--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -23,13 +23,13 @@ const GameSettings = () => (
         <div>
           <Checkbox side="left" text="Beep on new packs" link="beep" />
         </div>}
-        <div>
-          <Checkbox side="left" text="Use column view" link="cols" />
-        </div>
         {!App.state.isSealed && 
         <div>
           <Checkbox side="left" text="Hide your picks" link="hidepicks" />
         </div>}
+        <div>
+          <Checkbox side="left" text="Use column view" link="cols" />
+        </div>
         <SortCards />
         <CardsImageQuality />
       </span>

--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -24,7 +24,7 @@ const GameSettings = () => (
           <Checkbox side="left" text="Beep on new packs" link="beep" />
         </div>}
         <div>
-          <Checkbox side="left" text="Column view" link="cols" />
+          <Checkbox side="left" text="Use column view" link="cols" />
         </div>
         {!App.state.isSealed && 
         <div>


### PR DESCRIPTION
We always use descriptive labels for the options in settings, not only tag words.

Fix that for "Column view".