### PR TITLE
hide move arrows when single player

### DIFF
--- a/public/src/game/PlayersPanel.jsx
+++ b/public/src/game/PlayersPanel.jsx
@@ -114,7 +114,7 @@ const PlayerEntry = ({player, index}) => {
 
   if (isHost) {
     //Move Player
-    if(!didGameStart)
+    if(!didGameStart && length > 1)
       columns.push(
         <td key={7}>
           <button onClick={()=> App.send("swap", [index, index - 1])}>


### PR DESCRIPTION
closes #725 

I chose not to hide arrows for the host, because it's more code to write and it doesn't feel right to me to move the other players when you want to move yourself.