### PR TITLE
fix RNA pack

### DIFF
--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -24,8 +24,8 @@ for (let name in Cards)
     name,
     cmc: 0,
     code: "BFZ",
-    color: "colorless",
-    rarity: "basic",
+    color: "Colorless",
+    rarity: "Basic",
     type: "Land",
     url: "https://api.scryfall.com/cards/multiverse/" + `${Cards[name]}` + "?format=image"
   };

--- a/src/pool.js
+++ b/src/pool.js
@@ -181,7 +181,7 @@ function toPack(code) {
   case "GRN":
   case "RNA": {
     // No basics. Always 1 common slots are occupied by guildgates
-    const guildGates = common.filter(cardName => getCards()[cardName].type === "Land" && getCards()[cardName].sets[code].rarity == "common");
+    const guildGates = common.filter(cardName => getCards()[cardName].type === "Land" && getCards()[cardName].sets[code].rarity == "Common");
     common = common.filter(cardName => !guildGates.includes(cardName)); //delete guildGates from possible choice as common slot
     pack.push(_.choose(1, guildGates));
     break;
@@ -305,7 +305,7 @@ function toCards(pool, code, foilCard, masterpiece) {
     }
 
     if (masterpiece == card.name.toString().toLowerCase()) {
-      card.rarity = "special";
+      card.rarity = "Special";
       card.foil = true;
       if (code == "BFZ" || code == "OGW") {
         card.code = "EXP";

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env node, mocha */
 const assert = require("assert");
 const Pool = require("../src/pool");
+const { getPlayableSets } = require("../src/data");
 
 describe("Acceptance tests for Pool class", () => {
   describe("can make a cube pool", () => {
@@ -54,6 +55,23 @@ describe("Acceptance tests for Pool class", () => {
     it("should return a timespiral pool", () => {
       const got = Pool.DraftNormal({playersLength: 1, sets: ["TSP"]});
       assert.equal(got[0].length, 14);
+    });
+  });
+
+  describe("can make all playable sets one set", () => {
+    it("should return a a normal booster", () => {
+      const playableSets = getPlayableSets();
+      Object.values(playableSets).forEach((sets) => {
+        sets.forEach(({code}) => {
+          if (code === "random") {
+            return;
+          }
+          const [got] = Pool.DraftNormal({playersLength: 1, sets: [code]});
+          got.forEach(card => {
+            assert.ok(card.name, `${code} has an error: ${card}`);
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
closes #753 

It appears that the capitalization of Colors and Rarity introduced a regression to how RNA and GRN packs are generated. 

This PR solves the problem by checking the correct rarity (Common instead of common) and also adds checks on others colors' types. 

Though everything would need a refactor to use the types from an enum or something. 

@ZeldaZach Does MTGJson holds JSON schema with maybe enums for colors, rarity etc?