### PR TITLE
Improve wording for notification settings

### DIFF
--- a/public/src/game/GameSettings.jsx
+++ b/public/src/game/GameSettings.jsx
@@ -10,11 +10,11 @@ const GameSettings = () => (
       <span>
         <Checkbox side="left" text="Show chat" link="chat" />
         {!App.state.isSealed &&
-          <Checkbox side="left" text="Beep on new packs" link="beep" />
+          <Checkbox side="left" text="Enable notifications on new packs" link="beep" />
         }
         {!App.state.isSealed &&
           <Checkbox side="left"
-            text={App.state.notificationBlocked ? "Browser notifications blocked" : "Use desktop notifications"}
+            text={App.state.notificationBlocked ? "Web notifications blocked in browser" : "Use desktop notifications over beep"}
             link="notify"
             disabled={!App.state.beep || App.state.notificationBlocked}
             onChange={App._emit("notification")} />


### PR DESCRIPTION
Partially addresses #744

The first is somehow a general switch.
The first turns beep notifications on.
The second is only selectable once the first is enabled.
The second disables the beep from the first.
The second enables desktop notifications via the browser (likely to trigger an os sound on notification event).

It's quite difficult to make clear that the options are dependent on each other, and how ticking the first is needed for the second even though the second disables something the first was providing (beep sound) while superseding that with a web notification and a different system sound most probably.

<br>

**This is a first, simple approach to improve the wording for now.**

---

A better solution would be to also stress the dependence from the first, and/or group the two notification settings and separate them a bit from the rest:
- with an indentation:
```
[x] Show chat
[x] Enable notifications on new packs
  [x] Use desktop notifications over beep
[ ] Add picks to sideboard
[ ] Hide your picks
[x] Use column view
```

- and/or via their own section for example:
```
[x] Enable notifications on new packs
[x] Use desktop notifications over beep

[x] Show chat
[ ] Add picks to sideboard
[ ] Hide your picks
[x] Use column view
```

But I've no idea how to implement that. @HerveH44, maybe you?