### PR TITLE
check emn double cards in booster

### DIFF
--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -74,4 +74,16 @@ describe("Acceptance tests for Pool class", () => {
       });
     });
   });
+  describe("EMN boosters do not have cards in multiple", () => {
+    it("1000 EMN boosters don't have cards in multiple unless double faced card", () => {
+      new Array(1000).fill().forEach(() => {
+        const [got] = Pool.DraftNormal({playersLength: 1, sets: ["EMN"]});
+        got.forEach(card => {
+          const isMultiple = got.filter(c => c.name === card.name && !c.foil).length > 1;
+          const isSpecial = card.rarity === "special" || card.isDoubleFaced || card.foil;
+          assert.ok(!isMultiple || isSpecial, `${card.name} is in multiple and was not special`);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
closes #770

Added a test to check if 1000 EMN boosters have double cards that are not expected (not "special", meaning not double-faced card or foil)