### PR TITLE
fix: cube cards must not be from masterpiece set

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -65,7 +65,7 @@ const writeCards = (newCards) => {
 
 const writeCubeCards = (allSets, allCards) => {
   const cubableCards = Object.values(allCards).filter(({setCode}) =>
-    allSets[setCode].type === "masterpiece"
+    allSets[setCode].type !== "masterpiece"
   );
   cubableCardsByName = keyCardsByName(cubableCards);
   fs.writeFileSync("data/cubable_cards_by_name.json", JSON.stringify(cubableCardsByName, undefined, 4));


### PR DESCRIPTION
fixes #883 

Actually it's a regression, we used to filter out the masterpieces before (see #121) from the v1.0 