### PR TITLE
add box as an acceptable set type

### DIFF
--- a/scripts/update_database.js
+++ b/scripts/update_database.js
@@ -9,7 +9,7 @@ const updateDatabase = () => {
 
   // Add normal sets
   const setsToIgnore = ["ITP", "CP1", "CP2", "CP3"];
-  const types = ["core", "expansion", "commander", "planechase", "starter", "funny", "masters", "draft_innovation", "masterpiece"];
+  const types = ["box","core", "expansion", "commander", "planechase", "starter", "funny", "masters", "draft_innovation", "masterpiece"];
   if (fs.existsSync("data/sets")) {
     const files = fs.readdirSync("data/sets");
     files.forEach(file => {


### PR DESCRIPTION
fixes #860 

@ZeldaZach if you accept to allow box set types to be part of our DB (but still not draftable / sealedable) you can accept this PR. 

It's a quick fix, just added the "box" set type (as GN2 has this type in MTGJson).