### PR TITLE
Fix cubable cards

### DIFF
--- a/backend/import/keyCards.js
+++ b/backend/import/keyCards.js
@@ -7,7 +7,7 @@ const keyBy = (getGroup, getValue, cards = []) => (
 
 const groupCardsBy = (getGroup, getValue, baseSetSize = 0, cards = []) => (
   cards.reduce((acc, card) => {
-    if (baseSetSize >= card.number) {
+    if (baseSetSize >= parseInt(card.number)) {
       const group = getGroup(card);
       (acc[group] = acc[group] || []).push(getValue(card));
     }

--- a/backend/import/keyCards.js
+++ b/backend/import/keyCards.js
@@ -23,6 +23,9 @@ const namePlucker = ({name}) => name.toLowerCase();
 const groupCardsUuidByRarity = (baseSetSize = 0, cards = []) =>
   groupCardsBy(rarityPlucker, uuidPlucker, baseSetSize, cards);
 
+const groupCardsByName = (cards = []) =>
+  groupCardsBy(namePlucker, card => card, 10000, cards);
+
 const keyCardsUuidByNumber = (cards = []) =>
   keyBy(numberPlucker, uuidPlucker, cards);
 
@@ -34,6 +37,7 @@ const keyCardsByUuid = (cards = []) =>
 
 module.exports = {
   groupCardsUuidByRarity,
+  groupCardsByName,
   keyCardsUuidByNumber,
   keyCardsByName,
   keyCardsByUuid


### PR DESCRIPTION
I found an interesting error in the logs, some special card (Hanweir Garrison) could not be cubable.

After checking, I found out that the cubable card grouping was skipping cards with a special number (like 123a) because it wasn't a real number. So I added a parseInt to cast the number to a pure int. 

