### PR TITLE
allow mosts sets to be playable

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -119,7 +119,7 @@ const getPlayableSets = () => {
     const { type, name, releaseDate } = AllSets[code];
 
     //We do not want to play with these types of set
-    if (["masterpiece", "planechase", "commander", "timeshifted"].includes(type)) {
+    if (!["core", "draft_innovation", "expansion", "funny", "starter", "masters", "custom"].includes(type)) {
       continue;
     }
 

--- a/backend/data.js
+++ b/backend/data.js
@@ -116,10 +116,10 @@ const getPlayableSets = () => {
 
   const AllSets = getSets();
   for (let code in AllSets) {
-    const { type, name, releaseDate, baseSetSize } = AllSets[code];
+    const { type, name, releaseDate } = AllSets[code];
 
-    //We do not want to play with these types of set (unplayable or lacking cards)
-    if (["masterpiece", "planechase", "commander", "timeshifted"].includes(type) || baseSetSize === 0) {
+    //We do not want to play with these types of set
+    if (["masterpiece", "planechase", "commander", "timeshifted"].includes(type)) {
       continue;
     }
 

--- a/backend/game.spec.js
+++ b/backend/game.spec.js
@@ -15,7 +15,6 @@ describe("Acceptance tests for Game class", () => {
       };
 
       const got = new Game(gameParams);
-      const value = await axios.get("https://cubecobra.com/cube/api/cubelist/dekkaru");
       assert.equal(got.type, "draft");
     });
   });

--- a/backend/import/doSet.js
+++ b/backend/import/doSet.js
@@ -1,7 +1,6 @@
 const toBoosterCard = require("./toBoosterCard");
 const { keyCardsUuidByNumber, groupCardsUuidByRarity, keyCardsByUuid} = require("./keyCards");
 
-// TODO: this set should return a set or cards?
 function doSet({code, baseSetSize, name, type, releaseDate, boosterV3, cards: mtgJsonCards}) {
   const cards = mtgJsonCards
     .filter((card) => !card.isAlternative)
@@ -16,7 +15,7 @@ function doSet({code, baseSetSize, name, type, releaseDate, boosterV3, cards: mt
     baseSetSize,
     size,
     cardsByNumber: keyCardsUuidByNumber(cards),
-    ...groupCardsUuidByRarity(baseSetSize, cards)
+    ...groupCardsUuidByRarity(cards)
   }, {
     ...keyCardsByUuid(cards)
   }];

--- a/backend/import/keyCards.js
+++ b/backend/import/keyCards.js
@@ -5,12 +5,10 @@ const keyBy = (getGroup, getValue, cards = []) => (
   }, {})
 );
 
-const groupCardsBy = (getGroup, getValue, baseSetSize = 0, cards = []) => (
+const groupCardsBy = (getGroup, getValue, cards = []) => (
   cards.reduce((acc, card) => {
-    if (baseSetSize >= parseInt(card.number)) {
-      const group = getGroup(card);
-      (acc[group] = acc[group] || []).push(getValue(card));
-    }
+    const group = getGroup(card);
+    (acc[group] = acc[group] || []).push(getValue(card));
     return acc;
   }, {})
 );
@@ -20,11 +18,11 @@ const numberPlucker = ({number}) => number;
 const uuidPlucker = ({uuid}) => uuid;
 const namePlucker = ({name}) => name.toLowerCase();
 
-const groupCardsUuidByRarity = (baseSetSize = 0, cards = []) =>
-  groupCardsBy(rarityPlucker, uuidPlucker, baseSetSize, cards);
+const groupCardsUuidByRarity = (cards = []) =>
+  groupCardsBy(rarityPlucker, uuidPlucker,cards);
 
 const groupCardsByName = (cards = []) =>
-  groupCardsBy(namePlucker, card => card, 10000, cards);
+  groupCardsBy(namePlucker, card => card, cards);
 
 const keyCardsUuidByNumber = (cards = []) =>
   keyBy(numberPlucker, uuidPlucker, cards);

--- a/backend/import/keyCards.spec.js
+++ b/backend/import/keyCards.spec.js
@@ -3,33 +3,8 @@ const assert = require("assert");
 const {groupCardsUuidByRarity} = require("./keyCards");
 
 describe("Acceptance tests for groupCardNamesByRarity function", () => {
-  it("does not add card that are with a baseSetSize bigger", () => {
-
-    const got = groupCardsUuidByRarity(1, [{
-      uuid: "test",
-      number: 2,
-      rarity: "test"
-    }]);
-
-    assert.deepEqual(got, {});
-  });
-  it("does add card that have with a number equal or less than baseSetSize", () => {
-    const got = groupCardsUuidByRarity(2, [{
-      uuid: "test",
-      number: 2,
-      rarity: "test"
-    },{
-      uuid: "test2",
-      number: 1,
-      rarity: "test"
-    }]);
-
-    assert.deepEqual(got, {
-      test: ["test", "test2"]
-    });
-  });
   it("does add cards according to their rarity", () => {
-    const got = groupCardsUuidByRarity(2, [{
+    const got = groupCardsUuidByRarity([{
       uuid: "test",
       number: 2,
       rarity: "rarity1"


### PR DESCRIPTION
closes #891 

I deleted the contol on baseSetSize to allow all sets that don't have this value in mtgjson to be playable (and this means a ton). Just check on the PR deployment to see by yourself.

Mystery boosters are available and playble from what I tested.  