### PR TITLE
Swap game options

### DIFF
--- a/frontend/src/game/StartPanel.jsx
+++ b/frontend/src/game/StartPanel.jsx
@@ -43,10 +43,10 @@ const Options = () => {
   return (
     <span>
       <Checkbox side="left" link="addBots" text="Fill empty seats with Bots"/>
+      <Checkbox side="left" link="shufflePlayers" text="Random seating"/>
       <div>
         <Checkbox side="left" link="useTimer" text="Timer: "/>
         <Select link="timerLength" opts={timers} disabled={!useTimer}/>
-        <Checkbox side="left" link="shufflePlayers" text="Random seating"/>
       </div>
     </span>
   );


### PR DESCRIPTION
Improve grouping of options.

Might help with https://github.com/dr4fters/dr4ft/issues/897#issuecomment-603027907, too.
A new "paragraph" above the two timer options would be even better.