### PR TITLE
Fix multi card same pack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -27,6 +27,7 @@
         "@babel/plugin-proposal-function-sent",
         "@babel/plugin-proposal-export-namespace-from",
         "@babel/plugin-proposal-numeric-separator",
-        "@babel/plugin-proposal-throw-expressions"
+        "@babel/plugin-proposal-throw-expressions",
+        "@babel/plugin-proposal-private-methods"
     ]
 }

--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -3,6 +3,7 @@ const logger = require("./logger");
 const boosterRules = require("../data/boosterRules.json");
 const weighted = require("weighted");
 const {sample, sampleSize, random, concat} = require("lodash");
+const draftId = require("uuid").v1;
 
 const makeBoosterFromRules = (setCode) => {
   const set = getSet(setCode);
@@ -53,7 +54,10 @@ const getDefaultBooster = (set) => {
     cardNames.push(sample(Basic));
   }
 
-  return cardNames.map(getCardByUuid);
+  return cardNames.map(getCardByUuid).map((card) => ({
+    ...card,
+    draftId: draftId()
+  }));
 };
 
 const chooseCards = sheets => ([sheetCode, numberOfCardsToPick]) => {
@@ -104,7 +108,8 @@ function getRandomCards({cards, totalWeight: total}, numberOfCardsToPick) {
 
 const toCard = (sheetCode) => (uuid) => ({
   ...getCardByUuid(uuid),
-  foil: /foil/.test(sheetCode)
+  foil: /foil/.test(sheetCode),
+  draftId: draftId()
 });
 
 module.exports = makeBoosterFromRules;

--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -3,7 +3,6 @@ const logger = require("./logger");
 const boosterRules = require("../data/boosterRules.json");
 const weighted = require("weighted");
 const {sample, sampleSize, random, concat} = require("lodash");
-const draftId = require("uuid").v1;
 
 const makeBoosterFromRules = (setCode) => {
   const set = getSet(setCode);
@@ -54,10 +53,7 @@ const getDefaultBooster = (set) => {
     cardNames.push(sample(Basic));
   }
 
-  return cardNames.map(getCardByUuid).map((card) => ({
-    ...card,
-    draftId: draftId()
-  }));
+  return cardNames.map(getCardByUuid);
 };
 
 const chooseCards = sheets => ([sheetCode, numberOfCardsToPick]) => {
@@ -108,8 +104,7 @@ function getRandomCards({cards, totalWeight: total}, numberOfCardsToPick) {
 
 const toCard = (sheetCode) => (uuid) => ({
   ...getCardByUuid(uuid),
-  foil: /foil/.test(sheetCode),
-  draftId: draftId()
+  foil: /foil/.test(sheetCode)
 });
 
 module.exports = makeBoosterFromRules;

--- a/backend/human.js
+++ b/backend/human.js
@@ -121,7 +121,7 @@ module.exports = class extends Player {
 
     this.pool.push(card);
     this.picks.push(pickcard);
-    this.send("add", card.name);
+    this.send("add", card);
 
     let [next] = this.packs;
     if (!next)

--- a/backend/pool.js
+++ b/backend/pool.js
@@ -6,7 +6,7 @@ const draftId = require("uuid").v1;
 /**
  * @desc add a unique id to a card
  * @param card
- * @returns {{cardId: string}}
+ * @returns {{...card, cardId: string}}
  */
 const addCardId = (card) => ({
   ...card,

--- a/backend/pool.js
+++ b/backend/pool.js
@@ -3,12 +3,17 @@ const boosterGenerator = require("./boosterGenerator");
 const { getCardByUuid, getCardByName, getRandomSet, getExpansionOrCoreModernSets: getModernList, getExansionOrCoreSets: getSetsList } = require("./data");
 const draftId = require("uuid").v1;
 
-const addDraftId = (card) => ({
+/**
+ * @desc add a unique id to a card
+ * @param card
+ * @returns {{cardId: string}}
+ */
+const addCardId = (card) => ({
   ...card,
-  draftId: draftId()
+  cardId: draftId()
 });
 
-const addDraftIdsToBoosterCards = (pack) => pack.map(addDraftId);
+const addCardIdsToBoosterCards = (pack) => pack.map(addCardId);
 
 const SealedCube = ({ cubeList, playersLength, playerPoolSize = 90 }) => {
   return DraftCube({
@@ -24,7 +29,7 @@ const DraftCube = ({ cubeList, playersLength, packsNumber = 3, playerPackSize = 
 
   return range(playersLength * packsNumber)
     .map(() => list.splice(0, playerPackSize).map(getCardByName))
-    .map(addDraftIdsToBoosterCards);
+    .map(addCardIdsToBoosterCards);
 };
 
 // Replace RNG set with real set
@@ -35,14 +40,14 @@ const replaceRNGSet = (sets) => (
 const SealedNormal = ({ playersLength, sets }) => (
   times(playersLength , constant(replaceRNGSet(sets)))
     .map(sets => sets.flatMap(boosterGenerator))
-    .map(addDraftIdsToBoosterCards)
+    .map(addCardIdsToBoosterCards)
 );
 
 const DraftNormal = ({ playersLength, sets }) => (
   replaceRNGSet(sets)
     .flatMap(set => times(playersLength, constant(set)))
     .map(boosterGenerator)
-    .map(addDraftIdsToBoosterCards)
+    .map(addCardIdsToBoosterCards)
 );
 
 // Get a random set and transform it to pack
@@ -88,14 +93,14 @@ const DraftChaos = ({ playersLength, packsNumber = 3, modernOnly, totalChaos }) 
 
   return range(playersLength * packsNumber)
     .map(() => totalChaos ? getTotalChaosPack(setList) : getRandomPack(setList))
-    .map(addDraftIdsToBoosterCards);
+    .map(addCardIdsToBoosterCards);
 };
 
 const SealedChaos = ({ playersLength, packsNumber = 6, modernOnly, totalChaos }) => {
   const pool = DraftChaos({playersLength, packsNumber, modernOnly, totalChaos});
   return range(playersLength)
     .map(() => pool.splice(0, packsNumber).flat())
-    .map(addDraftIdsToBoosterCards);
+    .map(addCardIdsToBoosterCards);
 };
 
 module.exports = {

--- a/backend/pool.spec.js
+++ b/backend/pool.spec.js
@@ -3,47 +3,59 @@
 const assert = require("assert");
 const Pool = require("./pool");
 const {range, times, constant} = require("lodash");
-const { getPlayableSets } = require("./data");
+const {getPlayableSets} = require("./data");
+
+const assertPackIsCorrect = (got) => {
+  const cardIds = new Set();
+  let expectedCardsSize = 0;
+  got.forEach(pool => pool.forEach(card => {
+    assert(card.name !== undefined);
+    assert(card.cardId !== undefined);
+    cardIds.add(card.cardId);
+    expectedCardsSize++;
+  }));
+  assert.equal(cardIds.size, expectedCardsSize, "cards should all have a unique ID");
+};
 
 describe("Acceptance tests for Pool class", () => {
   describe("can make a cube pool", () => {
     it("should return a sealed cube pool with length equal to player length", () => {
       const cubeList = times(720, constant("island"));
       const playersLength = 8;
-      const got = Pool.SealedCube({ cubeList, playersLength });
-      assert.equal(playersLength, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      const playerPoolSize = 90;
+      const got = Pool.SealedCube({cubeList, playersLength, playerPoolSize});
+      assert.equal(got.length, playersLength);
+      assertPackIsCorrect(got);
     });
 
     it("should return a draft cube pool with length equal to player length per playersPack", () => {
       const cubeList = times(720, constant("island"));
       const playersLength = 8;
       const packsNumber = 3;
-      const got = Pool.DraftCube({ cubeList, playersLength, packsNumber });
-      assert.equal(playersLength*packsNumber, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      const playerPackSize = 15;
+      const got = Pool.DraftCube({cubeList, playersLength, packsNumber, playerPackSize});
+      assert.equal(got.length, playersLength * packsNumber);
+      assertPackIsCorrect(got);
     });
   });
 
   describe("can make a normal pool", () => {
     it("should return a sealed pool with length equal to player length", () => {
-      const sets = times(6, constant("M19"));
+      const packsNumber = 6;
+      const sets = times(packsNumber, constant("M19"));
       const playersLength = 8;
-      const got = Pool.SealedNormal({ sets, playersLength });
-      assert.equal(playersLength, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      const got = Pool.SealedNormal({sets, playersLength});
+      assert.equal(got.length, playersLength);
+      assertPackIsCorrect(got);
     });
 
     it("should return a draft pool with length equal to player length per playersPack", () => {
-      const sets = times(3, constant("M19"));
+      const packsNumber = 3;
+      const sets = times(packsNumber, constant("M19"));
       const playersLength = 8;
-      const got = Pool.DraftNormal({ sets, playersLength });
-      assert.equal(playersLength * 3, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      const got = Pool.DraftNormal({sets, playersLength});
+      assert.equal(got.length, playersLength * packsNumber);
+      assertPackIsCorrect(got);
     });
   });
 
@@ -51,17 +63,16 @@ describe("Acceptance tests for Pool class", () => {
     it("should return a sealed chaos pool with length equal to player length", () => {
       const playersLength = 8;
       const got = Pool.SealedChaos({ modernOnly: true, totalChaos: true, playersLength });
-      assert.equal(playersLength, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      assert.equal(got.length, playersLength);
+      assertPackIsCorrect(got);
     });
 
     it("should return a draft chaos pool with length equal to player length per playersPack", () => {
       const playersLength = 8;
-      const got = Pool.DraftChaos({ modernOnly: true, totalChaos: true, playersLength });
-      assert.equal(playersLength * 3, got.length);
-      got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
-      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
+      const packsNumber = 3;
+      const got = Pool.DraftChaos({packsNumber, modernOnly: true, totalChaos: true, playersLength});
+      assert.equal(got.length, playersLength * packsNumber);
+      assertPackIsCorrect(got);
     });
   });
 
@@ -69,8 +80,7 @@ describe("Acceptance tests for Pool class", () => {
     it("should return a timespiral pool", () => {
       const [got] = Pool.DraftNormal({playersLength: 1, sets: ["TSP"]});
       assert.equal(got.length, 15);
-      got.forEach(card => assert(card.name != undefined));
-      got.forEach(card => assert(card.draftId != undefined));
+      assertPackIsCorrect([got]);
     });
   });
 
@@ -82,9 +92,8 @@ describe("Acceptance tests for Pool class", () => {
           if (code === "random" || Date.parse(releaseDate) > new Date() || code === "UST") {
             return;
           }
-          const [got] = Pool.DraftNormal({playersLength: 1, sets: [code]});
-          got.forEach(card => assert(card.name != undefined, `${code} has an error: ${card}`));
-          got.forEach(card => assert(card.draftId != undefined));
+          const got = Pool.DraftNormal({playersLength: 1, sets: [code]});
+          assertPackIsCorrect(got);
         });
       });
     });

--- a/backend/pool.spec.js
+++ b/backend/pool.spec.js
@@ -13,6 +13,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.SealedCube({ cubeList, playersLength });
       assert.equal(playersLength, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
 
     it("should return a draft cube pool with length equal to player length per playersPack", () => {
@@ -22,6 +23,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.DraftCube({ cubeList, playersLength, packsNumber });
       assert.equal(playersLength*packsNumber, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
   });
 
@@ -32,6 +34,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.SealedNormal({ sets, playersLength });
       assert.equal(playersLength, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
 
     it("should return a draft pool with length equal to player length per playersPack", () => {
@@ -40,6 +43,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.DraftNormal({ sets, playersLength });
       assert.equal(playersLength * 3, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
   });
 
@@ -49,6 +53,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.SealedChaos({ modernOnly: true, totalChaos: true, playersLength });
       assert.equal(playersLength, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
 
     it("should return a draft chaos pool with length equal to player length per playersPack", () => {
@@ -56,6 +61,7 @@ describe("Acceptance tests for Pool class", () => {
       const got = Pool.DraftChaos({ modernOnly: true, totalChaos: true, playersLength });
       assert.equal(playersLength * 3, got.length);
       got.forEach(pool => pool.forEach(card => assert(card.name != undefined)));
+      got.forEach(pool => pool.forEach(card => assert(card.draftId != undefined)));
     });
   });
 
@@ -64,6 +70,7 @@ describe("Acceptance tests for Pool class", () => {
       const [got] = Pool.DraftNormal({playersLength: 1, sets: ["TSP"]});
       assert.equal(got.length, 15);
       got.forEach(card => assert(card.name != undefined));
+      got.forEach(card => assert(card.draftId != undefined));
     });
   });
 
@@ -76,9 +83,8 @@ describe("Acceptance tests for Pool class", () => {
             return;
           }
           const [got] = Pool.DraftNormal({playersLength: 1, sets: [code]});
-          got.forEach(card => {
-            assert(card.name != undefined, `${code} has an error: ${card}`);
-          });
+          got.forEach(card => assert(card.name != undefined, `${code} has an error: ${card}`));
+          got.forEach(card => assert(card.draftId != undefined));
         });
       });
     });

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -3,6 +3,7 @@ import EventEmitter from "events";
 import {STRINGS} from "./config";
 import eio from "engine.io-client";
 import {times, constant} from "lodash";
+import GameState from "./gamestate";
 
 function message(msg) {
   let args = JSON.parse(msg);
@@ -68,6 +69,8 @@ let App = {
     pickNumber: 0,
     packSize: 15,
     gameSeats: 8, // seats of the game being played
+    gameState: null, // records the current state of cards is a GameState
+    gameStates: {}, // Object representation of the gameState
 
     get didGameStart() {
       // both round === 0 and round is undefined
@@ -132,6 +135,20 @@ let App = {
   send(...args) {
     let msg = JSON.stringify(args);
     this.ws.send(msg);
+  },
+  initGameState(id) {
+    const { gameStates } = App.state;
+    const onStateUpdated = (gameState) => {
+      App.save("gameStates", {
+        ...App.state.gameStates,
+        [id]: gameState
+      });
+    };
+    if (!gameStates[id] === id) {
+      App.state.gameState = new GameState(onStateUpdated);
+    } else {
+      App.state.gameState = new GameState(onStateUpdated, gameStates[id]);
+    }
   },
   error(err) {
     App.err = err;

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -138,17 +138,17 @@ let App = {
   },
   initGameState(id) {
     const { gameStates } = App.state;
-    const onStateUpdated = (gameState) => {
+    if (gameStates[id] !== id) {
+      App.state.gameState = new GameState();
+    } else {
+      App.state.gameState = new GameState(gameStates[id]);
+    }
+    App.state.gameState.on("updateGameState", (gameState) => {
       App.save("gameStates", {
         ...App.state.gameStates,
         [id]: gameState
       });
-    };
-    if (gameStates[id] !== id) {
-      App.state.gameState = new GameState(onStateUpdated);
-    } else {
-      App.state.gameState = new GameState(onStateUpdated, gameStates[id]);
-    }
+    });
   },
   error(err) {
     App.err = err;

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -138,14 +138,14 @@ let App = {
   },
   initGameState(id) {
     const { gameStates } = App.state;
-    if (gameStates[id] !== id) {
+    if (!gameStates[id]) {
       App.state.gameState = new GameState();
     } else {
       App.state.gameState = new GameState(gameStates[id]);
     }
     App.state.gameState.on("updateGameState", (gameState) => {
       App.save("gameStates", {
-        ...App.state.gameStates,
+        // ...App.state.gameStates,
         [id]: gameState
       });
     });

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -144,7 +144,7 @@ let App = {
         [id]: gameState
       });
     };
-    if (!gameStates[id] === id) {
+    if (gameStates[id] !== id) {
       App.state.gameState = new GameState(onStateUpdated);
     } else {
       App.state.gameState = new GameState(onStateUpdated, gameStates[id]);

--- a/frontend/src/cards.js
+++ b/frontend/src/cards.js
@@ -393,13 +393,13 @@ function cube() {
 
 function clickPack(card) {
   const pack = App.state.gameState.get(ZONE_PACK);
-  const index = findIndex(pack, ({draftId}) => draftId === card.draftId);
-  if (clickedCardId !== card.draftId) {
-    clickedCardId = card.draftId;
+  const index = findIndex(pack, ({cardId}) => cardId === card.cardId);
+  if (clickedCardId !== card.cardId) {
+    clickedCardId = card.cardId;
     // There may be duplicate cards in a pack, but only one copy of a card is
     // shown in the pick view. We must be sure to mark them all since we don't
     // know which one is being displayed.
-    pack.forEach(c => c.isAutopick = card.draftId === c.draftId);
+    pack.forEach(c => c.isAutopick = card.cardId === c.cardId);
     App.update();
     App.send("autopick", index);
   } else {

--- a/frontend/src/cards.js
+++ b/frontend/src/cards.js
@@ -1,18 +1,10 @@
 import _ from "utils/utils";
 import App from "./app";
 import {vanillaToast} from "vanilla-toast";
-import {times, constant} from "lodash";
+import {times, constant, countBy, findIndex, pullAt, pull, range, remove, keyBy} from "lodash";
+let clickedCardId;
 
-let Cards = {
-  Plains: 401994,
-  Island: 401927,
-  Swamp: 402059,
-  Mountain: 401961,
-  Forest: 401886
-};
-
-export let BASICS = Object.keys(Cards);
-let COLORS_TO_LANDS = {
+const COLORS_TO_LANDS = {
   "W": "Plains",
   "U": "Island",
   "B": "Swamp",
@@ -20,53 +12,59 @@ let COLORS_TO_LANDS = {
   "G": "Forest",
 };
 
-for (let name in Cards)
-  Cards[name] = {
-    name,
-    cmc: 0,
-    code: "BFZ",
-    color: "Colorless",
-    rarity: "Basic",
-    type: "Land",
-    url: `https://api.scryfall.com/cards/named?exact=${name.toLowerCase()}&format=image&version=${App.state.cardSize}`
-  };
+/**
+ * BASICS is an array of basic lands
+ */
+export const BASICS = Object.entries(COLORS_TO_LANDS)
+  .map(([colorSign, cardName]) => {
+    return {
+      name: cardName,
+      cmc: 0,
+      colorSign,
+      code: "BFZ",
+      color: "Colorless",
+      rarity: "Basic",
+      type: "Land",
+      manaCost: 0,
+      url: `https://api.scryfall.com/cards/named?exact=${cardName.toLowerCase()}&format=image&version=${App.state.cardSize}`
+    };
+  });
 
-let rawPack, clicked;
+const basicKeyByColor = keyBy(BASICS, "colorSign");
+
 export let Zones = {
-  pack: {},
-  main: {},
-  side: {},
-  junk: {}
+  pack: [],
+  main: [],
+  side: [],
+  junk: []
 };
 
 function hash() {
   const { main, side } = Zones;
-  App.send("hash", { main, side });
+  App.send("hash", {
+    main: countBy(main, ({name}) => name),
+    side: countBy(side, ({name}) => name)
+  });
 }
 
 let events = {
-  add(cardName) {
-    let zone = Zones[App.state.side ? "side" : "main"];
-    zone[cardName] || (zone[cardName] = 0);
-    zone[cardName]++;
+  add(card) {
+    const zone = Zones[App.state.side ? "side" : "main"];
+    zone.push(card);
     App.update();
   },
-  click(zoneName, cardName, e) {
+  click(zoneName, card, e) {
     if (zoneName === "pack")
-      return clickPack(cardName);
+      return clickPack(card);
 
-    let src = Zones[zoneName];
-    let dst = Zones[e.shiftKey
+    const src = Zones[zoneName];
+    const dst = Zones[e.shiftKey
       ? zoneName === "junk" ? "main" : "junk"
       : zoneName === "side" ? "main" : "side"];
 
-    dst[cardName] || (dst[cardName] = 0);
-
-    src[cardName]--;
-    dst[cardName]++;
-
-    if (!src[cardName])
-      delete src[cardName];
+    const cardIndex = findIndex(src, card);
+    pullAt(src, cardIndex);
+    dst.push(card);
 
     App.update();
   },
@@ -80,29 +78,21 @@ let events = {
     hash();
   },
   download() {
-    let { filename, filetype } = App.state;
-    let data = filetypes[filetype]();
+    const { filename, filetype } = App.state;
+    const data = filetypes[filetype]();
     _.download(data, filename + "." + filetype);
     hash();
   },
   start() {
-    let { addBots, useTimer, timerLength, shufflePlayers } = App.state;
-    let options = { addBots, useTimer, timerLength, shufflePlayers };
+    const { addBots, useTimer, timerLength, shufflePlayers } = App.state;
+    const options = { addBots, useTimer, timerLength, shufflePlayers };
     App.send("start", options);
   },
   pickNumber(pick) {
     App.save("pickNumber", pick);
   },
   pack(cards) {
-    rawPack = cards;
-    let pack = Zones.pack = {};
-
-    for (let card of cards) {
-      let { name } = card;
-      Cards[name] = card;
-      pack[name] || (pack[name] = 0);
-      pack[name]++;
-    }
+    Zones["pack"] = cards;
     App.update();
     const anchor = document.querySelector("#cardZone");
     if (anchor) {
@@ -194,27 +184,18 @@ let events = {
     App.save(type, sets);
   },
   pool(cards) {
-    ["main", "side", "junk"].forEach(zoneName => Zones[zoneName] = {});
-
-    let zone = Zones[App.state.side
-      ? "side"
-      : "main"];
-
-    for (let card of cards) {
-      let { name } = card;
-      Cards[name] = card;
-
-      zone[name] || (zone[name] = 0);
-      zone[name]++;
-    }
+    ["main", "side", "junk"].forEach((zoneName) => Zones[zoneName] = []);
+    Zones[App.state.side ? "side" : "main"] = cards;
     App.update();
   },
-  land(zoneName, cardName, e) {
-    let n = Number(e.target.value);
-    if (n)
-      Zones[zoneName][cardName] = n;
-    else
-      delete Zones[zoneName][cardName];
+  land(zoneName, card, e) {
+    const n = Number(e.target.value);
+    const zone = Zones[zoneName];
+    remove(zone, (c) => c.name == card.name);
+    // add n land
+    range(n).forEach(() => {
+      zone.push(card);
+    });
     App.update();
   },
   deckSize(e) {
@@ -226,37 +207,38 @@ let events = {
   suggestLands() {
     // Algorithm: count the number of mana symbols appearing in the costs of
     // the cards in the pool, then assign lands roughly commensurately.
-    let colors = ["W", "U", "B", "R", "G"];
-    let colorRegex = /{[^}]+}/g;
-    let manaSymbols = {};
+    const colors = ["W", "U", "B", "R", "G"];
+    const colorRegex = /{[^}]+}/g;
+    const manaSymbols = {};
     colors.forEach(x => manaSymbols[x] = 0);
 
     // Count the number of mana symbols of each type.
-    for (let card of Object.keys(Zones["main"])) {
-      let quantity = Zones["main"][card];
-      card = Cards[card];
-
+    for (const card of Zones["main"]) {
       if (!card.manaCost)
         continue;
-      let cardManaSymbols = card.manaCost.match(colorRegex);
+      const cardManaSymbols = card.manaCost.match(colorRegex);
 
-      for (let color of colors)
-        for (let symbol of cardManaSymbols)
+      for (const color of colors)
+        for (const symbol of cardManaSymbols)
           // Test to see if '{U}' contains 'U'. This also handles things like
           // '{G/U}' triggering both 'G' and 'U'.
           if (symbol.indexOf(color) !== -1)
-            manaSymbols[color] += quantity;
+            manaSymbols[color] += 1;
     }
 
     _resetLands();
     // NB: We could set only the sideboard lands of the colors we are using to
     // 5, but this reveals information to the opponent on Cockatrice (and
     // possibly other clients) since it tells the opponent the sideboard size.
-    colors.forEach(color => Zones["side"][COLORS_TO_LANDS[color]] = 5);
+    colors.forEach(color => {
+      range(5).forEach(() => {
+        Zones["side"].push(basicKeyByColor[color]);
+      });
+    });
 
-    colors = colors.filter(x => manaSymbols[x] > 0);
-    colors.forEach(x => manaSymbols[x] = Math.max(3, manaSymbols[x]));
-    colors.sort((a, b) => manaSymbols[b] - manaSymbols[a]);
+    const mainColors = colors.filter(x => manaSymbols[x] > 0);
+    mainColors.forEach(x => manaSymbols[x] = Math.max(3, manaSymbols[x]));
+    mainColors.sort((a, b) => manaSymbols[b] - manaSymbols[a]);
 
     // Round-robin choose the lands to go into the deck. For example, if the
     // mana symbol counts are W: 2, U: 2, B: 1, cycle through the sequence
@@ -280,30 +262,25 @@ let events = {
     //
     //   * The problem of deciding how to round land counts is now easy to
     //   solve.
-    let manaSymbolsToAdd = colors.map(color => manaSymbols[color]);
-    let colorsToAdd = [];
+    const manaSymbolsToAdd = mainColors.map(color => manaSymbols[color]);
+    const colorsToAdd = [];
     const emptyManaSymbols = () => !manaSymbolsToAdd.every(x => x === 0);
 
-    for (let i = 0; emptyManaSymbols(); i = (i + 1) % colors.length) {
+    for (let i = 0; emptyManaSymbols(); i = (i + 1) % mainColors.length) {
       if (manaSymbolsToAdd[i] === 0)
         continue;
-      colorsToAdd.push(colors[i]);
+      colorsToAdd.push(mainColors[i]);
       manaSymbolsToAdd[i]--;
     }
 
     if (colorsToAdd.length > 0) {
-      let mainDeckSize = Object.keys(Zones["main"])
-        .map(x => Zones["main"][x])
-        .reduce((a, b) => a + b);
-      let landsToAdd = App.state.deckSize - mainDeckSize;
+      const mainDeckSize = Zones["main"].length;
+      const landsToAdd = App.state.deckSize - mainDeckSize;
 
       let j = 0;
       for (let i = 0; i < landsToAdd; i++) {
-        let color = colorsToAdd[j];
-        let land = COLORS_TO_LANDS[color];
-        if (!Zones["main"][land])
-          Zones["main"][land] = 0;
-        Zones["main"][land]++;
+        const color = colorsToAdd[j];
+        Zones["main"].push(basicKeyByColor[color]);
 
         j = (j + 1) % colorsToAdd.length;
       }
@@ -349,9 +326,10 @@ let events = {
 };
 
 function _resetLands() {
-  Object.keys(COLORS_TO_LANDS).forEach((key) => {
-    let land = COLORS_TO_LANDS[key];
-    Zones["main"][land] = Zones["side"][land] = 0;
+  Object.values(COLORS_TO_LANDS).forEach((basicLandName) => {
+    ["main", "side", "junk"].forEach((zoneName) => {
+      remove(Zones[zoneName], ({name}) => basicLandName.toLowerCase() == name.toLowerCase());
+    });
   });
 }
 
@@ -360,8 +338,9 @@ for (let event in events)
 
 function codify(zone) {
   let arr = [];
-  for (let name in zone)
-    arr.push(`    <card number="${zone[name]}" name="${name}"/>`);
+  Object.entries(countBy(zone, "name")).forEach(([name, number]) => {
+    arr.push(`    <card number="${number}" name="${name}"/>`);
+  });
   return arr.join("\n");
 }
 
@@ -380,33 +359,35 @@ ${codify(Zones.side)}
 </cockatrice_deck>`;
   },
   mwdeck() {
-    let arr = []
-      ;["main", "side"].forEach(zoneName => {
-      let prefix = zoneName === "side" ? "SB: " : "";
-      let zone = Zones[zoneName];
-      for (let name in zone) {
-        let { code } = Cards[name];
-        let count = zone[name];
-        name = name.replace(" // ", "/");
-        arr.push(`${prefix}${count} [${code}] ${name}`);
-      }
+    const arr = [];
+    ["main", "side"].forEach(zoneName => {
+      const prefix = zoneName === "side" ? "SB: " : "";
+      const zone = countBy(Zones[zoneName], ({setCode, name}) => `${setCode}|${name}`);
+      Object.entries(zone).forEach(([cardName, count]) => {
+        const [code, name] = cardName.split("|");
+        const sanitizedName = name.replace(" // ", "/");
+        arr.push(`${prefix}${count} [${code}] ${sanitizedName}`);
+      });
     });
     return arr.join("\n");
   },
   json() {
     let { main, side } = Zones;
-    return JSON.stringify({ main, side }, null, 2);
+    return JSON.stringify({
+      main: countBy(main, "name"),
+      side: countBy(side, "name")
+    }, null, 2);
   },
   txt() {
-    let arr = []
-      ;["main", "side"].forEach(zoneName => {
-      if (zoneName === "side")
+    const arr = [];
+    ["main", "side"].forEach(zoneName => {
+      if (zoneName === "side") {
         arr.push("Sideboard");
-      let zone = Zones[zoneName];
-      for (let name in zone) {
-        let count = zone[name];
-        arr.push(count + " " + name);
       }
+      Object.entries(countBy(Zones[zoneName], "name"))
+        .forEach(([name, count])=> {
+          arr.push(`${count} ${name}`);
+        });
     });
     return arr.join("\n");
   }
@@ -431,22 +412,21 @@ function cube() {
   return { list, cards, packs, cubePoolSize };
 }
 
-function clickPack(cardName) {
-  let index = rawPack.findIndex(x => x.name === cardName);
-
-  if (clicked !== cardName) {
-    clicked = cardName;
+function clickPack(card) {
+  const index = findIndex(Zones["pack"], ({draftId}) => draftId == card.draftId);
+  if (clickedCardId !== card.draftId) {
+    clickedCardId = card.draftId;
     // There may be duplicate cards in a pack, but only one copy of a card is
     // shown in the pick view. We must be sure to mark them all since we don't
     // know which one is being displayed.
-    rawPack.forEach(card => card.isAutopick = card.name === cardName);
+    Zones["pack"].forEach(c => c.isAutopick = card.draftId === c.draftId);
     App.update();
     App.send("autopick", index);
-    return clicked;
+    return;
   }
 
-  clicked = null;
-  Zones.pack = {};
+  clickedCardId = null;
+  Zones.pack = [];
   App.update();
   App.send("pick", index);
 }
@@ -500,29 +480,21 @@ function sortLandsBeforeNonLands(lhs, rhs) {
 
 function resetZones() {
   Zones = {
-    pack: {},
-    main: {},
-    side: {},
-    junk: {}
+    pack: [],
+    main: [],
+    side: [],
+    junk: []
   };
 }
 
 export function getZone(zoneName) {
-  let zone = Zones[zoneName];
-
-  let cards = [];
-  for (let cardName in zone)
-    for (let i = 0; i < zone[cardName]; i++)
-      cards.push(Cards[cardName]);
-
-  let { sort } = App.state;
-  let groups = _.group(cards, sort);
-  for (let key in groups)
+  const cards = Zones[zoneName];
+  const { sort } = App.state;
+  const groups = _.group(cards, sort);
+  for (const key in groups) {
     _.sort(groups[key], sortLandsBeforeNonLands, "color", "cmc", "name");
-
-  groups = Key(groups, sort);
-
-  return groups;
+  }
+  return Key(groups, sort);
 }
 
 export function getZoneDisplayName(zoneName) {

--- a/frontend/src/cards.js
+++ b/frontend/src/cards.js
@@ -2,6 +2,12 @@ import _ from "utils/utils";
 import App from "./app";
 import {vanillaToast} from "vanilla-toast";
 import {times, constant, countBy, findIndex, pullAt, range, remove, keyBy} from "lodash";
+
+/**
+ * TODO: add autopickId to GameState
+ *  check when change of autopick or when a new pack arrives to modify the autopick value
+ *  or find a way to indicate what card is autopick
+ */
 let clickedCardId;
 
 const COLORS_TO_LANDS = {
@@ -37,45 +43,137 @@ const ZONE_SIDE = "side";
 const ZONE_PACK = "pack";
 const ZONE_JUNK = "junk";
 
-export const getZone = (zoneName) => Zones[zoneName];
 /**
  * @desc the holder of the cards mapped by zone
  * TODO: could be a Map or a Class ?
  * @type {{side: [], junk: [], main: [], pack: []}}
  */
-let Zones = {
-  pack: [],
-  main: [],
-  side: [],
-  junk: []
-};
+// let Zones = {
+//   pack: [],
+//   main: [],
+//   side: [],
+//   junk: []
+// };
+
+class GameState {
+  #inner;
+
+  constructor() {
+    this.#inner = new Map([
+      [ZONE_MAIN, []],
+      [ZONE_SIDE, []],
+      [ZONE_PACK, []],
+      [ZONE_JUNK, []]
+    ]);
+  }
+
+  get(zoneName) {
+    return this.#inner.get(zoneName);
+  }
+
+  countCardsByName(zoneName, fun = ({name}) => name) {
+    return this.countCardsBy(zoneName, fun);
+  }
+
+  countCardsBy(zoneName, fun) {
+    const zone = this.get(zoneName);
+    return countBy(zone, fun);
+  }
+
+  pack(cards) {
+    const pack = this.get(ZONE_PACK);
+    cards.forEach((card) => pack.push(card));
+  }
+
+  add(card) {
+    const zone = App.state.side ? ZONE_SIDE : ZONE_MAIN;
+    this.#inner.get(zone).push(card);
+  }
+
+  move(fromZone, toZone, card) {
+    const src = this.get(fromZone);
+    const dst = this.get(toZone);
+    const cardIndex = findIndex(src, card);
+    pullAt(src, cardIndex);
+    dst.push(card);
+  }
+
+  reset() {
+    this.#inner.forEach((zone) => zone.length = 0);
+  }
+
+  addToPool(cards) {
+    cards
+      .filter((card) => {
+        return this.get(ZONE_MAIN).includes(card) ||
+          this.get(ZONE_SIDE).includes(card) ||
+          this.get(ZONE_JUNK).includes(card);
+      })
+      .forEach(this.add);
+  }
+
+  setLands(zoneName, card, n) {
+    const zone = this.get(zoneName);
+    remove(zone, (c) => c.name === card.name);
+    // add n land
+    range(n).forEach(() => {
+      zone.push(card);
+    });
+  }
+
+  resetLands() {
+    Object.values(COLORS_TO_LANDS).forEach((basicLandName) => {
+      [ZONE_MAIN, ZONE_SIDE, ZONE_JUNK].forEach((zoneName) => {
+        remove(this.get(zoneName), ({name}) => basicLandName.toLowerCase() === name.toLowerCase());
+      });
+    });
+  }
+
+  getMainDeckSize() {
+    return this.get(ZONE_MAIN).length;
+  }
+
+  addToMain(card) {
+    this.get(ZONE_MAIN).push(card);
+  }
+
+  getSortedZone(zoneName) {
+    const cards = this.get(zoneName);
+    const {sort} = App.state;
+    const groups = _.group(cards, sort);
+    for (const key in groups) {
+      _.sort(groups[key], sortLandsBeforeNonLands, "color", "cmc", "name");
+    }
+    return Key(groups, sort);
+  }
+}
+
+const gameState = new GameState();
+
+export const getZone = (zoneName) => gameState.get(zoneName);
+
 
 function hash() {
-  const { main, side } = Zones;
   App.send("hash", {
-    main: countBy(main, ({name}) => name),
-    side: countBy(side, ({name}) => name)
+    main: gameState.countCardsByName(ZONE_MAIN),
+    side: gameState.countCardsByName(ZONE_SIDE),
   });
 }
 
 let events = {
   add(card) {
-    const zone = Zones[App.state.side ? ZONE_SIDE : ZONE_MAIN];
-    zone.push(card);
+    gameState.add(card);
     App.update();
   },
   click(zoneName, card, e) {
     if (zoneName === ZONE_PACK)
       return clickPack(card);
 
-    const src = Zones[zoneName];
-    const dst = Zones[e.shiftKey
+    const dst = e.shiftKey
       ? zoneName === ZONE_JUNK ? ZONE_MAIN : ZONE_JUNK
-      : zoneName === ZONE_SIDE ? ZONE_MAIN : ZONE_SIDE];
+      : zoneName === ZONE_SIDE ? ZONE_MAIN : ZONE_SIDE;
 
-    const cardIndex = findIndex(src, card);
-    pullAt(src, cardIndex);
-    dst.push(card);
+    gameState.move(zoneName, dst, card);
 
     App.update();
   },
@@ -89,21 +187,21 @@ let events = {
     hash();
   },
   download() {
-    const { filename, filetype } = App.state;
+    const {filename, filetype} = App.state;
     const data = filetypes[filetype]();
     _.download(data, filename + "." + filetype);
     hash();
   },
   start() {
-    const { addBots, useTimer, timerLength, shufflePlayers } = App.state;
-    const options = { addBots, useTimer, timerLength, shufflePlayers };
+    const {addBots, useTimer, timerLength, shufflePlayers} = App.state;
+    const options = {addBots, useTimer, timerLength, shufflePlayers};
     App.send("start", options);
   },
   pickNumber(pick) {
     App.save("pickNumber", pick);
   },
   pack(cards) {
-    Zones[ZONE_PACK] = cards;
+    gameState.pack(cards);
     App.update();
     const anchor = document.querySelector("#cardZone");
     if (anchor) {
@@ -119,7 +217,7 @@ let events = {
         }
       } else {
         const beep = document.getElementById("beep");
-        if(beep) {
+        if (beep) {
           beep.play();
         }
       }
@@ -129,7 +227,7 @@ let events = {
     App.state.log = draftLog;
   },
   getLog() {
-    const { id, log, players, self, sets, gamesubtype, filename } = App.state;
+    const {id, log, players, self, sets, gamesubtype, filename} = App.state;
     const isCube = /cube/.test(gamesubtype);
     const date = new Date().toISOString().slice(0, -5).replace(/-/g, "").replace(/:/g, "").replace("T", "_");
     let data = [
@@ -154,18 +252,18 @@ let events = {
   },
 
   create() {
-    let { gametype, gamesubtype, seats, title, isPrivate, modernOnly, totalChaos, chaosDraftPacksNumber, chaosSealedPacksNumber } = App.state;
+    let {gametype, gamesubtype, seats, title, isPrivate, modernOnly, totalChaos, chaosDraftPacksNumber, chaosSealedPacksNumber} = App.state;
     seats = Number(seats);
 
     //TODO: either accept to use the legacy types (draft, sealed, chaos draft ...) by  keeping it like this
     // OR change backend to accept "regular draft" instead of "draft" and "regular sealed" instead of "sealed"
     const type = `${/regular/.test(gamesubtype) ? "" : gamesubtype + " "}${gametype}`;
 
-    let options = { type, seats, title, isPrivate, modernOnly, totalChaos };
+    let options = {type, seats, title, isPrivate, modernOnly, totalChaos};
 
-    switch(gamesubtype) {
+    switch (gamesubtype) {
     case "regular": {
-      const { setsDraft, setsSealed } = App.state;
+      const {setsDraft, setsSealed} = App.state;
       options.sets = gametype === "sealed" ? setsSealed : setsDraft;
       break;
     }
@@ -176,7 +274,7 @@ let events = {
       options.chaosPacksNumber = /draft/.test(gametype) ? chaosDraftPacksNumber : chaosSealedPacksNumber;
       break;
     }
-    resetZones();
+    gameState.reset();
     App.send("create", options);
   },
   changeSetsNumber(type, event) {
@@ -195,18 +293,12 @@ let events = {
     App.save(type, sets);
   },
   pool(cards) {
-    [ZONE_MAIN, ZONE_SIDE, ZONE_JUNK].forEach((zoneName) => Zones[zoneName] = []);
-    Zones[App.state.side ? ZONE_SIDE : ZONE_MAIN] = cards;
+    gameState.addToPool(cards);
     App.update();
   },
   land(zoneName, card, e) {
     const n = Number(e.target.value);
-    const zone = Zones[zoneName];
-    remove(zone, (c) => c.name === card.name);
-    // add n land
-    range(n).forEach(() => {
-      zone.push(card);
-    });
+    gameState.setLands(zoneName, card, n);
     App.update();
   },
   deckSize(e) {
@@ -224,7 +316,7 @@ let events = {
     colors.forEach(x => manaSymbols[x] = 0);
 
     // Count the number of mana symbols of each type.
-    for (const card of Zones[ZONE_MAIN]) {
+    for (const card of gameState.get(ZONE_MAIN)) {
       if (!card.manaCost)
         continue;
       const cardManaSymbols = card.manaCost.match(colorRegex);
@@ -237,13 +329,13 @@ let events = {
             manaSymbols[color] += 1;
     }
 
-    _resetLands();
+    gameState.resetLands();
     // NB: We could set only the sideboard lands of the colors we are using to
     // 5, but this reveals information to the opponent on Cockatrice (and
     // possibly other clients) since it tells the opponent the sideboard size.
     colors.forEach(color => {
       range(5).forEach(() => {
-        Zones[ZONE_SIDE].push(basicKeyByColor[color]);
+        gameState.get(ZONE_SIDE).push(basicKeyByColor[color]);
       });
     });
 
@@ -285,13 +377,13 @@ let events = {
     }
 
     if (colorsToAdd.length > 0) {
-      const mainDeckSize = Zones[ZONE_MAIN].length;
+      const mainDeckSize = gameState.getMainDeckSize();
       const landsToAdd = App.state.deckSize - mainDeckSize;
 
       let j = 0;
       for (let i = 0; i < landsToAdd; i++) {
         const color = colorsToAdd[j];
-        Zones[ZONE_MAIN].push(basicKeyByColor[color]);
+        gameState.addToMain(basicKeyByColor[color]);
 
         j = (j + 1) % colorsToAdd.length;
       }
@@ -300,7 +392,7 @@ let events = {
     App.update();
   },
   resetLands() {
-    _resetLands();
+    gameState.resetLands();
     App.update();
   },
   chat(messages) {
@@ -336,14 +428,6 @@ let events = {
   },
 };
 
-function _resetLands() {
-  Object.values(COLORS_TO_LANDS).forEach((basicLandName) => {
-    [ZONE_MAIN, ZONE_SIDE, ZONE_JUNK].forEach((zoneName) => {
-      remove(Zones[zoneName], ({name}) => basicLandName.toLowerCase() === name.toLowerCase());
-    });
-  });
-}
-
 for (let event in events)
   App.on(event, events[event]);
 
@@ -362,10 +446,10 @@ let filetypes = {
 <cockatrice_deck version="1">
   <deckname>${App.state.filename}</deckname>
   <zone name="main">
-${codify(Zones.main)}
+${codify(gameState.get(ZONE_MAIN))}
   </zone>
   <zone name="side">
-${codify(Zones.side)}
+${codify(gameState.get(ZONE_SIDE))}
   </zone>
 </cockatrice_deck>`;
   },
@@ -373,7 +457,7 @@ ${codify(Zones.side)}
     const arr = [];
     [ZONE_MAIN, ZONE_SIDE].forEach(zoneName => {
       const prefix = zoneName === ZONE_SIDE ? "SB: " : "";
-      const zone = countBy(Zones[zoneName], ({setCode, name}) => `${setCode}|${name}`);
+      const zone = gameState.countCardsBy(zoneName, ({setCode, name}) => `${setCode}|${name}`);
       Object.entries(zone).forEach(([cardName, count]) => {
         const [code, name] = cardName.split("|");
         const sanitizedName = name.replace(" // ", "/");
@@ -383,10 +467,9 @@ ${codify(Zones.side)}
     return arr.join("\n");
   },
   json() {
-    let { main, side } = Zones;
     return JSON.stringify({
-      main: countBy(main, "name"),
-      side: countBy(side, "name")
+      main: gameState.countCardsByName(ZONE_MAIN),
+      side: gameState.countCardsByName(ZONE_SIDE)
     }, null, 2);
   },
   txt() {
@@ -395,8 +478,8 @@ ${codify(Zones.side)}
       if (zoneName === ZONE_SIDE) {
         arr.push("Sideboard");
       }
-      Object.entries(countBy(Zones[zoneName], "name"))
-        .forEach(([name, count])=> {
+      Object.entries(gameState.countCardsByName(zoneName))
+        .forEach(([name, count]) => {
           arr.push(`${count} ${name}`);
         });
     });
@@ -405,7 +488,7 @@ ${codify(Zones.side)}
 };
 
 function cube() {
-  let { list, cards, packs, cubePoolSize } = App.state;
+  let {list, cards, packs, cubePoolSize} = App.state;
   cards = Number(cards);
   packs = Number(packs);
   cubePoolSize = Number(cubePoolSize);
@@ -420,26 +503,26 @@ function cube() {
     .filter(x => x)
     .join("\n");
 
-  return { list, cards, packs, cubePoolSize };
+  return {list, cards, packs, cubePoolSize};
 }
 
 function clickPack(card) {
-  const index = findIndex(Zones[ZONE_PACK], ({draftId}) => draftId === card.draftId);
+  const pack = gameState.get(ZONE_PACK);
+  const index = findIndex(pack, ({draftId}) => draftId === card.draftId);
   if (clickedCardId !== card.draftId) {
     clickedCardId = card.draftId;
     // There may be duplicate cards in a pack, but only one copy of a card is
     // shown in the pick view. We must be sure to mark them all since we don't
     // know which one is being displayed.
-    Zones[ZONE_PACK].forEach(c => c.isAutopick = card.draftId === c.draftId);
+    pack.forEach(c => c.isAutopick = card.draftId === c.draftId);
     App.update();
     App.send("autopick", index);
-    return;
+  } else {
+    clickedCardId = null;
+    pack.length = 0;
+    App.update();
+    App.send("pick", index);
   }
-
-  clickedCardId = null;
-  Zones.pack = [];
-  App.update();
-  App.send("pick", index);
 }
 
 function Key(groups, sort) {
@@ -463,13 +546,13 @@ function Key(groups, sort) {
 
   case "color":
     keys =
-        ["Colorless", "White", "Blue", "Black", "Red", "Green", "Multicolor"]
-          .filter(x => keys.indexOf(x) > -1);
+      ["Colorless", "White", "Blue", "Black", "Red", "Green", "Multicolor"]
+        .filter(x => keys.indexOf(x) > -1);
     break;
   case "rarity":
     keys =
-        ["Mythic", "Rare", "Uncommon", "Common", "Basic", "Special"]
-          .filter(x => keys.indexOf(x) > -1);
+      ["Mythic", "Rare", "Uncommon", "Common", "Basic", "Special"]
+        .filter(x => keys.indexOf(x) > -1);
     break;
   case "type":
     keys = keys.sort();
@@ -489,32 +572,22 @@ function sortLandsBeforeNonLands(lhs, rhs) {
   return rhsIsLand - lhsIsLand;
 }
 
-function resetZones() {
-  Zones = {
-    pack: [],
-    main: [],
-    side: [],
-    junk: []
-  };
-}
-
 export function getSortedZone(zoneName) {
-  const cards = Zones[zoneName];
-  const { sort } = App.state;
-  const groups = _.group(cards, sort);
-  for (const key in groups) {
-    _.sort(groups[key], sortLandsBeforeNonLands, "color", "cmc", "name");
-  }
-  return Key(groups, sort);
+  return gameState.getSortedZone(zoneName);
 }
 
 export function getZoneDisplayName(zoneName) {
   switch (zoneName) {
-  case ZONE_PACK: return "Pack";
-  case ZONE_MAIN: return "Main Deck";
-  case ZONE_SIDE: return "Sideboard";
-  case ZONE_JUNK: return "Junk";
-  default: return "UNKNOWN ZONENAME";
+  case ZONE_PACK:
+    return "Pack";
+  case ZONE_MAIN:
+    return "Main Deck";
+  case ZONE_SIDE:
+    return "Sideboard";
+  case ZONE_JUNK:
+    return "Junk";
+  default:
+    return "UNKNOWN ZONENAME";
   }
 }
 

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -66,7 +66,7 @@ const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
         <div
           className={`${card.foil ? "foil-card": ""} card-col`}
           key={index}
-          onClick={App._emit("click", zoneName, card.name)}
+          onClick={App._emit("click", zoneName, card)}
           onMouseOver={e => onMouseOver(card, e)}
           onMouseLeave={onMouseLeave} >
 

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 
 import App from "../app";
-import {getZone, getZoneDisplayName, getCardSrc, getFallbackSrc} from "../cards";
+import {getSortedZone, getZoneDisplayName, getCardSrc, getFallbackSrc} from "../cards";
 import {Spaced} from "../utils.jsx";
 
 class Cols extends Component {
@@ -57,7 +57,7 @@ Cols.propTypes = {
 
 const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
   const renderZone = (zoneName) => {
-    const zone = getZone(zoneName);
+    const zone = getSortedZone(zoneName);
     let sum = 0;
     let cols = [];
 

--- a/frontend/src/game/DeckSettings.jsx
+++ b/frontend/src/game/DeckSettings.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import App from "../app";
-import {BASICS, getZone, getZoneDisplayName} from "../cards";
+import {getZone, getZoneDisplayName} from "../cards";
+import {BASICS} from "../gamestate";
 import {Select} from "../utils";
 
 const DeckSettings = () => (

--- a/frontend/src/game/DeckSettings.jsx
+++ b/frontend/src/game/DeckSettings.jsx
@@ -51,14 +51,14 @@ const ManaSymbols = () => {
 const LandsRow = ({zoneName}) => (
   <tr>
     <td>{getZoneDisplayName(zoneName)}</td>
-    {BASICS.map((cardName, index) =>
+    {BASICS.map((card, index) =>
       <td key={index}>
         <input
           className='number'
           min={0}
-          onChange={App._emit("land", zoneName, cardName)}
+          onChange={App._emit("land", zoneName, card)}
           type='number'
-          value={Zones[zoneName][cardName] || 0}/>
+          value={Zones[zoneName].filter((c) => c.name == card.name).length || 0}/>
       </td>)}
   </tr>
 );

--- a/frontend/src/game/DeckSettings.jsx
+++ b/frontend/src/game/DeckSettings.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import App from "../app";
-import {BASICS, Zones, getZoneDisplayName} from "../cards";
+import {BASICS, getZone, getZoneDisplayName} from "../cards";
 import {Select} from "../utils";
 
 const DeckSettings = () => (
@@ -58,7 +58,7 @@ const LandsRow = ({zoneName}) => (
           min={0}
           onChange={App._emit("land", zoneName, card)}
           type='number'
-          value={Zones[zoneName].filter((c) => c.name == card.name).length || 0}/>
+          value={getZone(zoneName).filter((c) => c.name == card.name).length || 0}/>
       </td>)}
   </tr>
 );

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -58,7 +58,7 @@ class Card extends Component {
   onMouseEnter() {
     if (this.props.card.isDoubleFaced) {
       this.setState({
-        isDoubleFaced: true,
+        mouseEntered: true,
         url: getCardSrc({
           ...this.props.card,
           isBack: this.props.card.flippedIsBack,
@@ -74,7 +74,7 @@ class Card extends Component {
       this.setState({
         url: getCardSrc(this.props.card),
         flipped: false,
-        isDoubleFaced: false
+        mouseEntered: false
       });
     }
   }
@@ -98,7 +98,7 @@ class Card extends Component {
         onClick={App._emit("click", zoneName, card)}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}>
-        <CardImage isDoubleFaced={this.state.isDoubleFaced} imgUrl={this.state.url} {...card}/>
+        <CardImage mouseEntered={this.state.mouseEntered} imgUrl={this.state.url} {...card}/>
       </span>
     );
   }
@@ -109,7 +109,7 @@ Card.propTypes = {
   zoneName: PropTypes.string.isRequired
 };
 
-const CardImage = ({ isDoubleFaced, url, flippedIsBack, flippedNumber, imgUrl, scryfallId = "", name, manaCost, type = "", rarity = "", power = "", toughness = "", text = "", loyalty= "", setCode = "", number = "" }) => (
+const CardImage = ({ mouseEntered, url, flippedIsBack, flippedNumber, imgUrl, scryfallId = "", name, manaCost, type = "", rarity = "", power = "", toughness = "", text = "", loyalty= "", setCode = "", number = "" }) => (
   App.state.cardSize === "text"
     ? <div style={{display: "block"}}>
       <p><strong>{name}</strong> {manaCost}</p>
@@ -120,7 +120,7 @@ const CardImage = ({ isDoubleFaced, url, flippedIsBack, flippedNumber, imgUrl, s
     </div>
     : <img title={name}
       onError= {getFallbackSrc({url: imgUrl, scryfallId, setCode, number})}
-      src={!isDoubleFaced
+      src={!mouseEntered
         ? getCardSrc({ scryfallId, setCode, url, number })
         : getCardSrc({ scryfallId, setCode, url, number: flippedNumber, isBack: flippedIsBack })
       }
@@ -143,7 +143,7 @@ CardImage.propTypes = {
   setCode: PropTypes.string,
   number: PropTypes.string,
   scryfallId: PropTypes.string,
-  isDoubleFaced: PropTypes.bool,
+  mouseEntered: PropTypes.bool,
   url: PropTypes.string,
   flippedIsBack: PropTypes.bool,
   flippedNumber: PropTypes.string,

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import _ from "utils/utils";
 import App from "../app";
-import {getZone, getZoneDisplayName, getCardSrc, getFallbackSrc} from "../cards";
+import {getSortedZone, getZoneDisplayName, getCardSrc, getFallbackSrc} from "../cards";
 import {Spaced} from "../utils";
 
 const Grid = ({zones}) => (
@@ -17,7 +17,7 @@ Grid.propTypes = {
 };
 
 const zone = (zoneName, index) => {
-  const zone = getZone(zoneName);
+  const zone = getSortedZone(zoneName);
   const zoneDisplayName = getZoneDisplayName(zoneName);
   const values = _.values(zone);
   const cards = _.flat(values);

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -95,7 +95,7 @@ class Card extends Component {
     return (
       <span className={className}
         title={title}
-        onClick={App._emit("click", zoneName, card.name)}
+        onClick={App._emit("click", zoneName, card)}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}>
         <CardImage isDoubleFaced={this.state.isDoubleFaced} imgUrl={this.state.url} {...card}/>

--- a/frontend/src/gamestate.js
+++ b/frontend/src/gamestate.js
@@ -67,12 +67,17 @@ class GameState {
     this.#onStateUpdated(this.inner);
   }
 
+  /**
+   *
+   * @param {string} zoneName
+   * @param {array} cards
+   */
   addToPool(zoneName, cards) {
     cards
       .filter((card) => {
-        return !this.get(ZONE_MAIN).includes(card) &&
-          !this.get(ZONE_SIDE).includes(card) &&
-          !this.get(ZONE_JUNK).includes(card);
+        return !this.get(ZONE_MAIN).map(({draftId}) => draftId).includes(card.draftId)
+          && !this.get(ZONE_SIDE).map(({draftId}) => draftId).includes(card.draftId) &&
+          !this.get(ZONE_JUNK).map(({draftId}) => draftId).includes(card.draftId);
       })
       .forEach((card) => {
         this.add(zoneName, card);

--- a/frontend/src/gamestate.js
+++ b/frontend/src/gamestate.js
@@ -70,9 +70,9 @@ class GameState {
   addToPool(zoneName, cards) {
     cards
       .filter((card) => {
-        return this.get(ZONE_MAIN).includes(card) ||
-          this.get(ZONE_SIDE).includes(card) ||
-          this.get(ZONE_JUNK).includes(card);
+        return !this.get(ZONE_MAIN).includes(card) &&
+          !this.get(ZONE_SIDE).includes(card) &&
+          !this.get(ZONE_JUNK).includes(card);
       })
       .forEach((card) => {
         this.add(zoneName, card);

--- a/frontend/src/gamestate.js
+++ b/frontend/src/gamestate.js
@@ -75,9 +75,9 @@ class GameState extends EventEmitter {
   addToPool(zoneName, cards) {
     cards
       .filter((card) => {
-        return !this.get(ZONE_MAIN).map(({draftId}) => draftId).includes(card.draftId)
-          && !this.get(ZONE_SIDE).map(({draftId}) => draftId).includes(card.draftId) &&
-          !this.get(ZONE_JUNK).map(({draftId}) => draftId).includes(card.draftId);
+        return !this.get(ZONE_MAIN).map(({cardId}) => cardId).includes(card.cardId)
+          && !this.get(ZONE_SIDE).map(({cardId}) => cardId).includes(card.cardId) &&
+          !this.get(ZONE_JUNK).map(({cardId}) => cardId).includes(card.cardId);
       })
       .forEach((card) => {
         this.add(zoneName, card);

--- a/frontend/src/gamestate.js
+++ b/frontend/src/gamestate.js
@@ -1,0 +1,168 @@
+import {countBy, findIndex, pullAt, range, remove} from "lodash";
+import _ from "utils/utils";
+
+export const ZONE_MAIN = "main";
+export const ZONE_SIDE = "side";
+export const ZONE_PACK = "pack";
+export const ZONE_JUNK = "junk";
+
+export const COLORS_TO_LANDS = {
+  "W": "Plains",
+  "U": "Island",
+  "B": "Swamp",
+  "R": "Mountain",
+  "G": "Forest",
+};
+
+const defaultState = {
+  [ZONE_MAIN]: [],
+  [ZONE_SIDE]: [],
+  [ZONE_PACK]: [],
+  [ZONE_JUNK]: []
+};
+
+class GameState {
+  inner;
+  #onStateUpdated;
+
+  constructor(onStateUpdated, state = defaultState) {
+    this.#onStateUpdated = onStateUpdated;
+    this.inner = state;
+  }
+
+  /**
+   * @param zoneName
+   * @returns {array}
+   */
+  get(zoneName) {
+    return this.inner[zoneName];
+  }
+
+  countCardsByName(zoneName, fun = ({name}) => name) {
+    return this.countCardsBy(zoneName, fun);
+  }
+
+  countCardsBy(zoneName, fun) {
+    const zone = this.get(zoneName);
+    return countBy(zone, fun);
+  }
+
+  pack(cards) {
+    this.inner[ZONE_PACK] = cards;
+    this.#onStateUpdated(this.inner);
+  }
+
+  add(zoneName, card) {
+    const zone = this.get(zoneName);
+    zone.push(card);
+    this.#onStateUpdated(this.inner);
+  }
+
+  move(fromZone, toZone, card) {
+    const src = this.get(fromZone);
+    const dst = this.get(toZone);
+    const cardIndex = findIndex(src, card);
+    pullAt(src, cardIndex);
+    dst.push(card);
+    this.#onStateUpdated(this.inner);
+  }
+
+  addToPool(zoneName, cards) {
+    cards
+      .filter((card) => {
+        return this.get(ZONE_MAIN).includes(card) ||
+          this.get(ZONE_SIDE).includes(card) ||
+          this.get(ZONE_JUNK).includes(card);
+      })
+      .forEach((card) => {
+        this.add(zoneName, card);
+      });
+    this.#onStateUpdated(this.inner);
+  }
+
+  setLands(zoneName, card, n) {
+    const zone = this.get(zoneName);
+    remove(zone, (c) => c.name === card.name);
+    // add n land
+    range(n).forEach(() => {
+      zone.push(card);
+    });
+    this.#onStateUpdated(this.inner);
+  }
+
+  resetLands() {
+    Object.values(COLORS_TO_LANDS).forEach((basicLandName) => {
+      [ZONE_MAIN, ZONE_SIDE, ZONE_JUNK].forEach((zoneName) => {
+        remove(this.get(zoneName), ({name}) => basicLandName.toLowerCase() === name.toLowerCase());
+      });
+    });
+    this.#onStateUpdated(this.inner);
+  }
+
+  getMainDeckSize() {
+    return this.get(ZONE_MAIN).length;
+  }
+
+  addToMain(card) {
+    this.get(ZONE_MAIN).push(card);
+    this.#onStateUpdated(this.inner);
+  }
+
+  getSortedZone(zoneName, sort) {
+    const cards = this.get(zoneName);
+    const groups = _.group(cards, sort);
+    for (const key in groups) {
+      _.sort(groups[key], sortLandsBeforeNonLands, "color", "cmc", "name");
+    }
+    return Key(groups, sort);
+  }
+}
+
+function sortLandsBeforeNonLands(lhs, rhs) {
+  let isLand = x => x.type.toLowerCase().indexOf("land") !== -1;
+  let lhsIsLand = isLand(lhs);
+  let rhsIsLand = isLand(rhs);
+  return rhsIsLand - lhsIsLand;
+}
+
+function Key(groups, sort) {
+  let keys = Object.keys(groups);
+  let arr;
+
+  switch (sort) {
+  case "cmc":
+    arr = [];
+    for (let key in groups)
+      if (parseInt(key) >= 6) {
+        [].push.apply(arr, groups[key]);
+        delete groups[key];
+      }
+
+    if (arr.length) {
+      groups["6+"] || (groups["6+"] = [])
+      ;[].push.apply(groups["6+"], arr);
+    }
+    return groups;
+
+  case "color":
+    keys =
+      ["Colorless", "White", "Blue", "Black", "Red", "Green", "Multicolor"]
+        .filter(x => keys.indexOf(x) > -1);
+    break;
+  case "rarity":
+    keys =
+      ["Mythic", "Rare", "Uncommon", "Common", "Basic", "Special"]
+        .filter(x => keys.indexOf(x) > -1);
+    break;
+  case "type":
+    keys = keys.sort();
+    break;
+  }
+
+  let o = {};
+  for (let key of keys)
+    o[key] = groups[key];
+  return o;
+}
+
+export default GameState;

--- a/frontend/src/gamestate.js
+++ b/frontend/src/gamestate.js
@@ -49,13 +49,13 @@ class GameState extends EventEmitter {
 
   pack(cards) {
     this.#state[ZONE_PACK] = cards;
-    this.#updState();
+    this.updState();
   }
 
   add(zoneName, card) {
     const zone = this.get(zoneName);
     zone.push(card);
-    this.#updState();
+    this.updState();
   }
 
   move(fromZone, toZone, card) {
@@ -64,7 +64,7 @@ class GameState extends EventEmitter {
     const cardIndex = findIndex(src, card);
     pullAt(src, cardIndex);
     dst.push(card);
-    this.#updState();
+    this.updState();
   }
 
   /**
@@ -99,7 +99,7 @@ class GameState extends EventEmitter {
         remove(this.get(zoneName), ({name}) => basicLandName.toLowerCase() === name.toLowerCase());
       });
     });
-    this.#updState();
+    this.updState();
   }
 
   getMainDeckSize() {
@@ -108,7 +108,7 @@ class GameState extends EventEmitter {
 
   addToMain(card) {
     this.get(ZONE_MAIN).push(card);
-    this.#updState();
+    this.updState();
   }
 
   getSortedZone(zoneName, sort) {
@@ -120,7 +120,7 @@ class GameState extends EventEmitter {
     return Key(groups, sort);
   }
 
-  #updState() {
+  updState() {
     this.emit("updateGameState", { gameState: this.#state });
   }
 }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -19,14 +19,15 @@ function route() {
 
   switch(route) {
   case "g":
+    App.initGameState(id);
+    App.state.players = [];
+    App.send("join", id);
+    App.once("gameInfos", App.updateGameInfos);
     component = (
       <Suspense fallback={<div>Loading...</div>}>
         <Game id={ id } />
       </Suspense>
     );
-    App.state.players = [];
-    App.send("join", id);
-    App.once("gameInfos", App.updateGameInfos);
     break;
   case "":
     component = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -601,6 +601,15 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.8.3.tgz",
+      "integrity": "sha512-ysLAper960yy1TVXa2lMYdCQIGqtUXo8sVb+zYE7UTiZSLs6/wbZ0PrrXEKESJcK3SgFWrF8WpsaDzdslhuoZA==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-throw-expressions": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/plugin-proposal-function-sent": "^7.8.3",
     "@babel/plugin-proposal-json-strings": "^7.8.3",
     "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+    "@babel/plugin-proposal-private-methods": "^7.8.3",
     "@babel/plugin-proposal-throw-expressions": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.8.3",


### PR DESCRIPTION
closes #969 

This is a big change of how we handle cards in the frontend. Until now we were using a global list of cards that we were accessing by name which resulted in the bug depicted in #969 when two different cards with the same name were indistinguishable (when you clicked on one, it would click on both, or they would be both foil when only one should be, or the contrary, none of them would be foil when one should be). This was an issue on how we saved the cards. 

I changed that by introducing a new class "GameState" that handles the state of the different zones' cards. It helped also implement a nice feature which is that when you click refresh (f5) the cards disposition (your main / side cards, number of lands you inserted). I really feel that would be helpful. 

It still needs some testing as it's mostly frontend and I don't know how to test it.  