### PR TITLE
Better separation of date and time in filename

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -208,8 +208,8 @@ let App = {
   updateGameInfos({type, sets, packsInfo}) {
     const savename = type === "draft" ? sets[0] + "-draft" : type;
     const date = new Date();
-    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "-" + date.getTime().toString().slice(-8, -3);
-    const filename = `${savename.replace(/\W/, "-")}-${currentTime}`;
+    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "_" + date.getTime().toString().slice(-8, -3);
+    const filename = `${savename.replace(/\W/, "-")}_${currentTime}`;
 
     App.set({
       filename,


### PR DESCRIPTION
`-` is already used for the separation of year, month and day (e.g. `2020-04-23`)

Will change the suggested filename
from `IKO-draft-2020-04-23-24523`
to `IKO-draft_2020-04-23_24523` for easier reading.

---

As seen above, the time value is still cryptic and needs proper conversation to local user time.