### PR TITLE
use local user time

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -208,7 +208,7 @@ let App = {
   updateGameInfos({type, sets, packsInfo}) {
     const savename = type === "draft" ? sets[0] + "-draft" : type;
     const date = new Date();
-    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "_" + date.getTime().toString().slice(-8, -3);
+    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "_" + date.toString().slice(16,21).replace(":", "-");
     const filename = `${savename.replace(/\W/, "-")}_${currentTime}`;
 
     App.set({

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -208,7 +208,7 @@ let App = {
   updateGameInfos({type, sets, packsInfo}) {
     const savename = type === "draft" ? sets[0] + "-draft" : type;
     const date = new Date();
-    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "_" + date.toString().slice(16,21).replace(":", "-");
+    const currentTime = date.toISOString().slice(0, 10).replace("T", " ") + "_" + date.toString().slice(16, 21).replace(":", "-");
     const filename = `${savename.replace(/\W/, "-")}_${currentTime}`;
 
     App.set({


### PR DESCRIPTION
The predefined filenames for deck downloads used to be `chaos-draft_2020-04-23_48265`.
Now it holds the proper local time for every user `chaos-draft_2020-04-23_15-26`.

Format is <kbd>GAMETYPE</kbd> _ <kbd>YYYY-MM-DD</kbd> _ <kbd>HH-MM</kbd>