### PR TITLE
Fix import cockatrice v4

### DIFF
--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -1,6 +1,7 @@
-const {getCardByUuid, getSet} = require("./data");
+const {getDataDir, getCardByUuid, getSet} = require("./data");
 const logger = require("./logger");
-const boosterRules = require("../data/boosterRules.json");
+const path = require("path");
+const boosterRules = require(path.join(getDataDir(), "boosterRules.json"));
 const weighted = require("weighted");
 const {sample, sampleSize, random, concat} = require("lodash");
 

--- a/backend/data.spec.js
+++ b/backend/data.spec.js
@@ -15,10 +15,10 @@ describe("Acceptance tests for Data functions", () => {
     it("data directory as absolute path", () => {
       const repoRoot = process.env.INIT_CWD;
       const dataDir = data.getDataDir();
-      
+
       assert(dataDir);
       assert(path.isAbsolute(dataDir));
-      assert(dataDir === `${repoRoot}/data`);
+      assert.equal(dataDir, `${repoRoot}/data`);
     });
   });
 });

--- a/backend/import/toBoosterCard.js
+++ b/backend/import/toBoosterCard.js
@@ -102,7 +102,7 @@ function getColor({ colors, layout, name, names = [], frameEffects = [] }, rawCa
   }
 
   // Handle split cards colors
-  if (layout === "split" && names.length > 1) {
+  if (["split", "aftermath"].includes(layout) && names.length > 1) {
     const otherName = names.filter((n) => n !== name)[0];
     const otherCard = find(rawCards, (card) => card.name === otherName);
     if (otherCard && otherCard.colors) {

--- a/backend/import/toBoosterCard.js
+++ b/backend/import/toBoosterCard.js
@@ -1,4 +1,4 @@
-const { upperFirst } = require("lodash");
+const { upperFirst, find } = require("lodash");
 const uuid_v1 = require("uuid").v1;
 
 const toBoosterCard = (setCode) => (mtgjsonCard, index, rawCards) => {
@@ -33,7 +33,7 @@ const toBoosterCard = (setCode) => (mtgjsonCard, index, rawCards) => {
     name = names.join(" // ");
 
   const {isDoubleFaced, flippedCardURL, flippedIsBack, flippedNumber} = getDoubleFacedProps(mtgjsonCard, rawCards);
-  const color = upperFirst(getColor(mtgjsonCard));
+  const color = upperFirst(getColor(mtgjsonCard, rawCards));
 
   return {
     uuid,
@@ -96,9 +96,22 @@ function getDoubleFacedProps({layout, names}, rawCards) {
   };
 }
 
-function getColor({ colors, frameEffects = [] }) {
+function getColor({ colors, layout, name, names = [], frameEffects = [] }, rawCards) {
   if (frameEffects.includes("devoid")) {
     return "colorless";
+  }
+
+  // Handle split cards colors
+  if (layout === "split" && names.length > 1) {
+    const otherName = names.filter((n) => n !== name)[0];
+    const otherCard = find(rawCards, (card) => card.name === otherName);
+    if (otherCard && otherCard.colors) {
+      for (const color of otherCard.colors) {
+        if (!colors.includes(color)) {
+          return "multicolor";
+        }
+      }
+    }
   }
 
   switch (colors.length) {

--- a/backend/import/toBoosterCard.spec.js
+++ b/backend/import/toBoosterCard.spec.js
@@ -307,6 +307,51 @@ describe("Acceptance tests for toBoosterCard function", () => {
       assert(dirtyParsed.cmc == 7, "split card CMC must equal to both side CMC");
     });
 
+    it("parse a split card with correct colors", () => {
+      const ice = {
+        "colorIdentity": ["R", "U"],
+        "colors": ["U"],
+        "convertedManaCost": 4.0,
+        "layout": "split",
+        "manaCost": "{1}{U}",
+        "name": "Ice",
+        "names": ["Fire", "Ice"],
+        "number": "128",
+        "rarity": "uncommon",
+        "scryfallId": "f98f4538-5b5b-475d-b98f-49d01dae6f04",
+        "side": "b",
+        "subtypes": [],
+        "supertypes": [],
+        "text": "Tap target permanent.\nDraw a card.",
+        "type": "Instant",
+        "types": ["Instant"],
+        "uuid": "3fe4b8e5-54dd-538d-b891-6016547aff15"
+      };
+      const fire = {
+        "colorIdentity": ["R", "U"],
+        "colors": ["R"],
+        "convertedManaCost": 4.0,
+        "layout": "split",
+        "manaCost": "{1}{R}",
+        "name": "Fire",
+        "names": ["Fire", "Ice"],
+        "number": "128",
+        "rarity": "uncommon",
+        "scryfallId": "f98f4538-5b5b-475d-b98f-49d01dae6f04",
+        "side": "a",
+        "subtypes": [],
+        "supertypes": [],
+        "text": "Fire deals 2 damage divided as you choose among one or two targets.",
+        "type": "Instant",
+        "types": ["Instant"],
+        "uuid": "bcef8350-ed57-5e3a-bffe-a3f9d955512e"
+      };
+
+      const [iceParsed, fireParsed] = [ice, fire].map(toBoosterCard("setCode"));
+      assert.equal(iceParsed.color, "Multicolor", "A split card’s colors are determined from its combined mana cost");
+      assert.equal(fireParsed.color, "Multicolor", "A split card’s colors are determined from its combined mana cost");
+    });
+
     it("parse a card with multiple color identities as mono color", () => {
       const multicolorCard = {
         "colorIdentity": ["B", "R"],

--- a/backend/import/xml/parser.js
+++ b/backend/import/xml/parser.js
@@ -82,6 +82,7 @@ function parse(content) {
     const set = jsonSets[setCode];
     set.cards.push({
       name: c.name,
+      names: getNames(layout, c.name),
       manaCost: manacost,
       cmc,
       loyalty,
@@ -104,14 +105,21 @@ function parse(content) {
   return jsonSets;
 }
 
+const getNames = (layout, name) => {
+  if (/split|aftermath|adventure/i.test(layout)) {
+    return name.split(" // ");
+  }
+  return [name];
+};
+
 const getTrueType = (type) => (
   type.split("-")[0].trim()
 );
 
 const getTrueColors = (version, colorv3, colorsv4) => (
   version === "3"
-    ? Array.isArray(colorv3) ? colorv3 : [colorv3]
-    : Array.isArray(colorsv4) ? colorsv4 : [colorsv4]
+    ? Array.isArray(colorv3) ? colorv3 : colorv3.split("")
+    : Array.isArray(colorsv4) ? colorsv4 : colorsv4.split("")
 );
 
 module.exports = {

--- a/backend/import/xml/parser.spec.js
+++ b/backend/import/xml/parser.spec.js
@@ -64,6 +64,7 @@ describe("Unit tests for XML Cockatrice Parser", () => {
             loyalty: 4,
             manaCost: "R",
             name: "Card name",
+            names: ["Card name"],
             number: 42,
             power: "",
             rarity: "common",
@@ -79,6 +80,65 @@ describe("Unit tests for XML Cockatrice Parser", () => {
           name: "MagicFest 2020",
           releaseDate: "2020-01-01",
           type: "Promo"
+        }
+      });
+    });
+    it("can parse split cards", () => {
+      const result = parser.parse(`
+      <cockatrice_carddatabase version="4">
+  <sets>
+    <set>
+      <name>IPR</name>
+      <longname>IPA Remastered</longname>
+      <settype>Custom</settype>
+      <releasedate>2020-04-10</releasedate>
+    </set>
+  </sets>
+  <cards>
+      <card>
+        <name>Fire // Ice</name>
+        <text>Fire deals 2 damage divided as you choose among one or two targets.  --- Tap target permanent. Draw a card.</text>
+        <prop>
+          <layout>split</layout>
+          <type>Instant</type>
+          <maintype>Instant</maintype>
+          <manacost>1R // 1U</manacost>
+          <cmc>4</cmc>
+          <colors>RU</colors>
+          <coloridentity>RU</coloridentity>
+        </prop>
+        <set rarity="uncommon" uuid="ae92942b-919c-4ea9-b693-85fcef765d5a" picurl="https://img.scryfall.com/cards/png/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.png?1562954160" num="302" muid="27165">IPR</set>
+        <tablerow>3</tablerow>
+      </card>
+  </cards>
+</cockatrice_carddatabase>`);
+      assert.deepEqual(result, {
+        IPR: {
+          baseSetSize: 1,
+          cards: [{
+            cmc: 4,
+            colors: ["R", "U"],
+            isAlternative: false,
+            layout: "split",
+            loyalty: "",
+            manaCost: "1R // 1U",
+            name: "Fire // Ice",
+            names: ["Fire", "Ice"],
+            number: 302,
+            power: "",
+            rarity: "uncommon",
+            side: "a",
+            supertypes: [],
+            text: "Fire deals 2 damage divided as you choose among one or two targets.  --- Tap target permanent. Draw a card.",
+            toughness: "",
+            type: "Instant",
+            types: ["Instant"],
+            url: "https://img.scryfall.com/cards/png/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.png?1562954160"
+          }],
+          code: "IPR",
+          name: "IPA Remastered",
+          releaseDate: "2020-04-10",
+          type: "Custom"
         }
       });
     });
@@ -120,6 +180,7 @@ describe("Unit tests for XML Cockatrice Parser", () => {
             loyalty: "",
             manaCost: "1W",
             name: "Aven Harrier",
+            names: ["Aven Harrier"],
             number: 0,
             power: 1,
             rarity: "common",
@@ -168,6 +229,7 @@ describe("Unit tests for XML Cockatrice Parser", () => {
             loyalty: "",
             manaCost: "1W",
             name: "Aven Harrier",
+            names: ["Aven Harrier"],
             number: 0,
             power: 1,
             rarity: "common",

--- a/backend/mtgjson.js
+++ b/backend/mtgjson.js
@@ -1,5 +1,7 @@
 const fs = require("fs");
-const VERSION_FILE = "data/version.json";
+const path = require("path");
+const {getDataDir} = require("../backend/data");
+const VERSION_FILE = path.join(getDataDir(), "version.json");
 const logger = require("./logger");
 const semver = require("semver");
 let version;

--- a/scripts/download_allsets.js
+++ b/scripts/download_allsets.js
@@ -11,7 +11,7 @@ const {getDataDir} = require("../backend/data");
 
 const mtgJsonURL = "https://www.mtgjson.com/files/AllSetFiles.zip";
 const versionURL = "https://www.mtgjson.com/files/version.json";
-const setsVersion = "data/version.json";
+const setsVersion = path.join(getDataDir(), "version.json");
 
 const isVersionNewer = ({ version: remoteVer }, { version: currentVer }) => (
   semver.gt(remoteVer, currentVer)


### PR DESCRIPTION
closes #960

@Kumarbis could you test on this PR deploy if you can import your custom set ? 

This is a fix to the import of the special split cards. 
I also fixed the split card color bug (we didn't take in consideration the other half color) and extended the "getDatadir" usage from #979 