### PR TITLE
ISSUE-919: Add a decadent draft game mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can also create a Docker image and run the app in a container:
 
 ## Usage
 
-### Start server
+### Start Server
 
 `npm start`
 
@@ -97,6 +97,31 @@ This command downloads integrates all files previously downloaded from MTGJson.
 
 `npm run download_booster_rules`
  download and parse booster generation rules from [magic-sealed-data](https://github.com/taw/magic-sealed-data)
+
+## Development Notes
+
+### VSCode
+
+You can debug this application by adding the following configuration to your `launch.json`:
+
+```json
+{
+  "name": "Launch via NPM",
+  "type": "node",
+  "request": "launch",
+  "cwd": "${workspaceFolder}",
+  "runtimeExecutable": "npm",
+  "runtimeArgs": [
+      "run", "start-debug"
+  ],
+  "port": 1338
+}
+```
+
+You should now be able to set breakpoints in `backend/` and hit them when you start the debugger.
+This relies on the `--inspect-brk=1338` flag to open port 1338 for the debugger to attach to.
+
+Breakpoints for the frontend should be set in your browser console.
 
 ### Contributors
 

--- a/backend/bot.js
+++ b/backend/bot.js
@@ -1,27 +1,20 @@
-const {sample, pull, pullAll} = require("lodash");
+const {sample, pull} = require("lodash");
 const Player = require("./player");
 
 module.exports = class extends Player {
-  constructor(isDecadent) {
+  constructor() {
     super({
       isBot: true,
       isConnected: true,
       name: "bot",
-      id: "",
-      isDecadent: isDecadent
+      id: ""
     });
   }
 
   getPack(pack) {
     const randomPick = sample(pack);
     this.picks.push(randomPick.name);
-    
-    if (!this.isDecadent) {
-      pull(pack, randomPick);
-    } else {
-      pullAll(pack, pack);
-    }
-    
+    pull(pack, randomPick);
     this.emit("pass", pack);
   }
 };

--- a/backend/bot.js
+++ b/backend/bot.js
@@ -1,20 +1,27 @@
-const {sample, pull} = require("lodash");
+const {sample, pull, pullAll} = require("lodash");
 const Player = require("./player");
 
 module.exports = class extends Player {
-  constructor() {
+  constructor(isDecadent) {
     super({
       isBot: true,
       isConnected: true,
       name: "bot",
-      id: ""
+      id: "",
+      isDecadent: isDecadent
     });
   }
 
   getPack(pack) {
     const randomPick = sample(pack);
     this.picks.push(randomPick.name);
-    pull(pack, randomPick);
+    
+    if (!this.isDecadent) {
+      pull(pack, randomPick);
+    } else {
+      pullAll(pack, pack);
+    }
+    
     this.emit("pass", pack);
   }
 };

--- a/backend/game.js
+++ b/backend/game.js
@@ -581,7 +581,7 @@ module.exports = class Game extends Room {
 
       if (addBots) {
         while (this.players.length < this.seats) {
-          this.players.push(new Bot(this.isDecadent));
+          this.players.push(new Bot());
           this.bots++;
         }
       }

--- a/backend/game.js
+++ b/backend/game.js
@@ -413,7 +413,7 @@ module.exports = class Game extends Room {
         this.meta();
       return;
     }
-    
+
     const index = this.players.indexOf(p) + this.delta;
     const nextPlayer = this.getNextPlayer(index);
     nextPlayer.getPack(pack);

--- a/backend/game.js
+++ b/backend/game.js
@@ -193,7 +193,63 @@ module.exports = class Game extends Room {
     super.join(sock);
     this.logger.debug(`${sock.name} joined the game`);
 
-    const h = new Human(sock, this.isDecadent);
+    function regularDraftPickDelegate(index) {
+      const pack = this.packs.shift();
+      const card = pack.splice(index, 1)[0];
+  
+      this.draftLog.pack.push( [`--> ${card.name}`].concat(pack.map(x => `    ${x.name}`)) );
+      this.updateDraftStats(this.draftLog.pack[ this.draftLog.pack.length-1 ], this.pool);
+  
+      let pickcard = card.name;
+      if (card.foil === true)
+        pickcard = "*" + pickcard + "*";
+  
+      this.pool.push(card);
+      this.picks.push(pickcard);
+      this.send("add", card);
+  
+      let [next] = this.packs;
+      if (!next)
+        this.time = 0;
+      else
+        this.sendPack(next);
+  
+      this.autopick_index = -1;
+      this.emit("pass", pack);
+    }
+
+    function decadentDraftPickDelegate(index) {
+      const pack = this.packs.shift();
+      const card = pack.splice(index, 1)[0];
+  
+      this.draftLog.pack.push( [`--> ${card.name}`].concat(pack.map(x => `    ${x.name}`)) );
+      this.updateDraftStats(this.draftLog.pack[ this.draftLog.pack.length-1 ], this.pool);
+  
+      let pickcard = card.name;
+      if (card.foil === true)
+        pickcard = "*" + pickcard + "*";
+  
+      this.pool.push(card);
+      this.picks.push(pickcard);
+      this.send("add", card);
+  
+      let [next] = this.packs;
+      if (!next)
+        this.time = 0;
+      else
+        this.sendPack(next);
+      
+      // Discard the rest of the cards in the pack
+      // after one is chosen.
+      pack.length = 0;
+  
+      this.autopick_index = -1;
+      this.emit("pass", pack);
+    }
+    
+    const draftPickDelegate = this.isDecadent ? decadentDraftPickDelegate : regularDraftPickDelegate;
+
+    const h = new Human(sock, draftPickDelegate);
     if (h.id === this.hostID) {
       h.isHost = true;
       sock.once("start", this.start.bind(this));

--- a/backend/game.js
+++ b/backend/game.js
@@ -38,7 +38,9 @@ module.exports = class Game extends Room {
       this.rounds = this.sets.length;
       break;
     case "decadent draft":
-      this.packsInfo = this.sets.join(" / ");
+      // Sets should all be the same and there can be a large number of them.
+      // Compress this info into e.g. "36x IKO" instead of "IKO / IKO / ...".
+      this.packsInfo = `${this.sets.length}x ${this.sets[0]}`;
       this.rounds = this.sets.length;
       this.isDecadent = true;
       break;

--- a/backend/game.js
+++ b/backend/game.js
@@ -574,12 +574,16 @@ module.exports = class Game extends Room {
     this.startRound();
   }
 
+  shouldAddBots() {
+    return this.addBots && !this.isDecadent;
+  }
+
   start({ addBots, useTimer, timerLength, shufflePlayers }) {
     try {
       Object.assign(this, { addBots, useTimer, timerLength, shufflePlayers });
       this.renew();
 
-      if (addBots) {
+      if (this.shouldAddBots()) {
         while (this.players.length < this.seats) {
           this.players.push(new Bot());
           this.bots++;

--- a/backend/human.js
+++ b/backend/human.js
@@ -1,16 +1,17 @@
 const Player = require("./player");
 const util = require("./util");
 const hash = require("./hash");
-const {random} = require("lodash");
+const {random, pullAll} = require("lodash");
 const logger = require("./logger");
 
 module.exports = class extends Player {
-  constructor(sock) {
+  constructor(sock, isDecadent) {
     super({
       isBot: false,
       isConnected: true,
       name: sock.name,
-      id: sock.id
+      id: sock.id,
+      isDecadent: isDecadent
     });
     this.attach(sock);
   }
@@ -130,6 +131,10 @@ module.exports = class extends Player {
       this.time = 0;
     else
       this.sendPack(next);
+
+    if (this.isDecadent) {
+      pullAll(pack, pack);
+    }
 
     this.autopick_index = -1;
     this.emit("pass", pack);

--- a/backend/human.js
+++ b/backend/human.js
@@ -1,18 +1,18 @@
 const Player = require("./player");
 const util = require("./util");
 const hash = require("./hash");
-const {random, pullAll} = require("lodash");
+const {random} = require("lodash");
 const logger = require("./logger");
 
 module.exports = class extends Player {
-  constructor(sock, isDecadent) {
+  constructor(sock, pickDelegate) {
     super({
       isBot: false,
       isConnected: true,
       name: sock.name,
-      id: sock.id,
-      isDecadent: isDecadent
+      id: sock.id
     });
+    this.pickDelegate = pickDelegate.bind(this);
     this.attach(sock);
   }
 
@@ -112,32 +112,7 @@ module.exports = class extends Player {
     this.draftStats.push( { picked, notPicked, pool: namePool } );
   }
   pick(index) {
-    const pack = this.packs.shift();
-    const card = pack.splice(index, 1)[0];
-
-    this.draftLog.pack.push( [`--> ${card.name}`].concat(pack.map(x => `    ${x.name}`)) );
-    this.updateDraftStats(this.draftLog.pack[ this.draftLog.pack.length-1 ], this.pool);
-
-    let pickcard = card.name;
-    if (card.foil === true)
-      pickcard = "*" + pickcard + "*";
-
-    this.pool.push(card);
-    this.picks.push(pickcard);
-    this.send("add", card);
-
-    let [next] = this.packs;
-    if (!next)
-      this.time = 0;
-    else
-      this.sendPack(next);
-
-    if (this.isDecadent) {
-      pullAll(pack, pack);
-    }
-
-    this.autopick_index = -1;
-    this.emit("pass", pack);
+    this.pickDelegate(index);
   }
   pickOnTimeout() {
     let index = this.autopick_index;

--- a/backend/player.js
+++ b/backend/player.js
@@ -5,7 +5,7 @@ const {EventEmitter} = require("events");
  * Abstract class for Human and Bot
  */
 class Player extends EventEmitter {
-  constructor({id, isBot, isConnected, name, isDecadent}) {
+  constructor({id, isBot, isConnected, name}) {
     super();
 
     if (this.constructor === Player) {
@@ -35,8 +35,7 @@ class Player extends EventEmitter {
       packSize: 15,
       self: 0,
       useTimer: false,
-      timeLength: "Slow",
-      isDecadent  // Pick a single card and discard the rest. Boujie!
+      timeLength: "Slow"
     });
   }
 

--- a/backend/player.js
+++ b/backend/player.js
@@ -5,7 +5,7 @@ const {EventEmitter} = require("events");
  * Abstract class for Human and Bot
  */
 class Player extends EventEmitter {
-  constructor({id, isBot, isConnected, name}) {
+  constructor({id, isBot, isConnected, name, isDecadent}) {
     super();
 
     if (this.constructor === Player) {
@@ -36,6 +36,7 @@ class Player extends EventEmitter {
       self: 0,
       useTimer: false,
       timeLength: "Slow",
+      isDecadent  // Pick a single card and discard the rest. Boujie!
     });
   }
 

--- a/backend/util.js
+++ b/backend/util.js
@@ -66,8 +66,17 @@ module.exports = {
     return true;
   },
   game({ seats, type, sets, cube, isPrivate, modernOnly = true, chaosPacksNumber, totalChaos = true }) {
-    assert(["draft", "sealed", "cube draft", "cube sealed", "chaos draft", "chaos sealed"].includes(type),
-      "type can be draft, sealed, chaos draft, chaos sealed, cube draft or cube sealed");
+    const acceptableGameTypes = [
+      "draft",
+      "sealed",
+      "cube draft",
+      "cube sealed",
+      "chaos draft",
+      "chaos sealed",
+      "decadent draft"
+    ];
+    assert(acceptableGameTypes.includes(type),
+      `type can be one of: ${acceptableGameTypes.join(", ")}`);
     assert(typeof isPrivate === "boolean", "isPrivate must be a boolean");
     assert(typeof seats === "number", "seats must be a number");
     assert(seats >= 1 && seats <= 100, "seats' number must be between 1 and 100");

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -82,6 +82,9 @@ let App = {
     get isGameFinished() {
       return App.state.round === -1;
     },
+    get isDecadentDraft() {
+      return /decadent draft/.test(App.state.game.type);
+    },
 
     get notificationBlocked() {
       return ["denied", "notsupported"].includes(App.state.notificationResult);

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -35,6 +35,7 @@ let App = {
     sets: [],
     setsDraft: [],
     setsSealed: [],
+    setsDecadentDraft: [],
     availableSets: {},
     list: "",
     cards: 15,
@@ -173,9 +174,10 @@ let App = {
     if (App.state.latestSet) {
       // Default sets to the latest set.
       const defaultSetCode = App.state.latestSet.code;
-      const multipleOfDefaultSet = (desiredLength) => times(desiredLength, constant(defaultSetCode));
-      App.state.setsSealed = multipleOfDefaultSet(6);
-      App.state.setsDraft = multipleOfDefaultSet(3);
+      const replicateDefaultSet = (desiredLength) => times(desiredLength, constant(defaultSetCode));
+      App.state.setsSealed = replicateDefaultSet(6);
+      App.state.setsDraft = replicateDefaultSet(3);
+      App.state.setsDecadentDraft = replicateDefaultSet(36);
     }
     App.update();
   },

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -170,12 +170,12 @@ let App = {
   },
   set(state) {
     Object.assign(App.state, state);
-    // Set default sets
-    if ( App.state.setsSealed.length === 0 && App.state.latestSet) {
-      App.state.setsSealed = times(6, constant(App.state.latestSet.code));
-    }
-    if ( App.state.setsDraft.length === 0 && App.state.latestSet) {
-      App.state.setsDraft = times(3, constant(App.state.latestSet.code));
+    if (App.state.latestSet) {
+      // Default sets to the latest set.
+      const defaultSetCode = App.state.latestSet.code;
+      const multipleOfDefaultSet = (desiredLength) => times(desiredLength, constant(defaultSetCode));
+      App.state.setsSealed = multipleOfDefaultSet(6);
+      App.state.setsDraft = multipleOfDefaultSet(3);
     }
     App.update();
   },

--- a/frontend/src/components/Checkbox.jsx
+++ b/frontend/src/components/Checkbox.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import App from "../app";
+
+const Checkbox = ({link, text, side, onChange, ...rest}) => (
+  <div>
+    {side === "right" ? text : ""}
+    <input
+      {...rest}
+      type="checkbox"
+      onChange={onChange || function (e) {
+        App.save(link, e.currentTarget.checked);
+      }}
+      checked={App.state[link]}/>
+    {side === "left" ? text : ""}
+  </div>
+);
+
+Checkbox.propTypes = {
+  link: PropTypes.string,
+  text: PropTypes.string,
+  side: PropTypes.string,
+  onChange: PropTypes.func
+};
+
+export default Checkbox;

--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -1,0 +1,5 @@
+# Components
+
+A set of general UI components.
+
+Many are "connected" tools which use a "link" prop to connect to the app state.

--- a/frontend/src/components/Select.jsx
+++ b/frontend/src/components/Select.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import App from "../app";
+
+const Select = ({
+  link,
+  opts,
+  onChange = (e) => { App.save(link, e.currentTarget.value); },
+  value = App.state[link],
+  ...rest}) => (
+  <select
+    onChange={onChange}
+    value={value}
+    {...rest}>
+    {opts.map((opt, index) =>
+      <option key={index}>{opt}</option>
+    )}
+  </select>
+);
+
+Select.propTypes = {
+  link: PropTypes.string,
+  onChange: PropTypes.func,
+  value: PropTypes.any,
+  opts: PropTypes.array
+};
+
+export default Select;

--- a/frontend/src/components/Spaced.jsx
+++ b/frontend/src/components/Spaced.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+const Spaced = ({elements}) => (
+  elements
+    .map((x, index) => <span key={index}>{x}</span>)
+    .reduce((prev, curr) => [
+      prev,
+      <span key = {prev+curr} className = 'spacer-dot' />,
+      curr
+    ])
+);
+
+export default Spaced;

--- a/frontend/src/components/TextArea.jsx
+++ b/frontend/src/components/TextArea.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import App from "../app";
+
+const TextArea = ({link, ...rest}) => (
+  <textarea
+    style={ {"overflowY": "scroll", "height": "150px"}}
+    onChange=
+      { (e) => { App.save("list", e.currentTarget.value); } }
+    value={App.state[link]}
+    {...rest} />
+);
+
+TextArea.propTypes = {
+  link: PropTypes.string
+};
+
+export default TextArea;

--- a/frontend/src/components/TextArea.jsx
+++ b/frontend/src/components/TextArea.jsx
@@ -5,11 +5,10 @@ import App from "../app";
 
 const TextArea = ({link, ...rest}) => (
   <textarea
-    style={ {"overflowY": "scroll", "height": "150px"}}
-    onChange=
-      { (e) => { App.save(link, e.currentTarget.value); } }
+    onChange={(e) => { App.save(link, e.currentTarget.value); }}
     value={App.state[link]}
-    {...rest} />
+    {...rest}
+  />
 );
 
 TextArea.propTypes = {

--- a/frontend/src/components/TextArea.jsx
+++ b/frontend/src/components/TextArea.jsx
@@ -7,7 +7,7 @@ const TextArea = ({link, ...rest}) => (
   <textarea
     style={ {"overflowY": "scroll", "height": "150px"}}
     onChange=
-      { (e) => { App.save("list", e.currentTarget.value); } }
+      { (e) => { App.save(link, e.currentTarget.value); } }
     value={App.state[link]}
     {...rest} />
 );

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -110,7 +110,8 @@ const events = {
     let options = {type, seats, title, isPrivate, modernOnly, totalChaos};
 
     switch (gamesubtype) {
-    case "regular": {
+    case "regular":
+    case "decadent": {
       const {setsDraft, setsSealed} = App.state;
       options.sets = gametype === "sealed" ? setsSealed : setsDraft;
       break;
@@ -124,10 +125,10 @@ const events = {
     }
     App.send("create", options);
   },
-  changeSetsNumber(type, event) {
+  changeSetsNumber(type, ensureAllSetsIdentical, event) {
     event.preventDefault();
     const packsNumber = event.currentTarget.value;
-    const sets = App.state[type];
+    let sets = App.state[type];
 
     if (sets.length < packsNumber) {
       const toAdd = packsNumber - sets.length;
@@ -135,6 +136,13 @@ const events = {
       sets.push(...times(toAdd, constant(lastSet)));
     } else if (sets.length > packsNumber) {
       sets.splice(packsNumber);
+    }
+
+    if (ensureAllSetsIdentical) {
+      const firstSet = sets[0];
+      for (let i = 1; i < sets.length; i++) {
+        sets[i] = firstSet;
+      }
     }
 
     App.save(type, sets);

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -109,22 +109,15 @@ const events = {
 
     let options = {type, seats, title, isPrivate, modernOnly, totalChaos};
 
-    if (gamesubtype === "decadent") {
-      // For decadent draft, all sets are the same.
-      const sets = App.state.setsDraft;
-      const firstSet = sets[0];
-      for (let i = 1; i < sets.length; i++) {
-        sets[i] = firstSet;
-      }
-    }
-
     switch (gamesubtype) {
-    case "regular":
-    case "decadent": {
+    case "regular": {
       const {setsDraft, setsSealed} = App.state;
       options.sets = gametype === "sealed" ? setsSealed : setsDraft;
       break;
     }
+    case "decadent":
+      options.sets = App.state.setsDecadentDraft;
+      break;
     case "cube":
       options.cube = parseCubeOptions();
       break;

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -109,6 +109,15 @@ const events = {
 
     let options = {type, seats, title, isPrivate, modernOnly, totalChaos};
 
+    if (gamesubtype === "decadent") {
+      // For decadent draft, all sets are the same.
+      const sets = App.state.setsDraft;
+      const firstSet = sets[0];
+      for (let i = 1; i < sets.length; i++) {
+        sets[i] = firstSet;
+      }
+    }
+
     switch (gamesubtype) {
     case "regular":
     case "decadent": {
@@ -125,10 +134,10 @@ const events = {
     }
     App.send("create", options);
   },
-  changeSetsNumber(type, ensureAllSetsIdentical, event) {
+  changeSetsNumber(type, event) {
     event.preventDefault();
     const packsNumber = event.currentTarget.value;
-    let sets = App.state[type];
+    const sets = App.state[type];
 
     if (sets.length < packsNumber) {
       const toAdd = packsNumber - sets.length;
@@ -136,13 +145,6 @@ const events = {
       sets.push(...times(toAdd, constant(lastSet)));
     } else if (sets.length > packsNumber) {
       sets.splice(packsNumber);
-    }
-
-    if (ensureAllSetsIdentical) {
-      const firstSet = sets[0];
-      for (let i = 1; i < sets.length; i++) {
-        sets[i] = firstSet;
-      }
     }
 
     App.save(type, sets);

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import App from "../app";
 import {getZoneDisplayName} from "../zones";
-import {Spaced} from "../utils.jsx";
+import Spaced from "../components/Spaced";
 import {getCardSrc, getFallbackSrc} from "../cardimage";
 
 class Cols extends Component {

--- a/frontend/src/game/DeckSettings.jsx
+++ b/frontend/src/game/DeckSettings.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import App from "../app";
 import {getZoneDisplayName, ZONE_MAIN, ZONE_SIDEBOARD} from "../zones";
 import {COLORS_TO_LANDS_NAME} from "../gamestate";
-import {Select} from "../utils";
+import Select from "../components/Select";
 
 const DeckSettings = () => (
   (App.state.isGameFinished || App.state.didGameStart)

--- a/frontend/src/game/GameSettings.jsx
+++ b/frontend/src/game/GameSettings.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import App from "../app";
-import {Checkbox} from "../utils";
+import Checkbox from "../components/Checkbox";
 
 const GameSettings = () => (
   <div className='game-settings'>

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -17,6 +17,23 @@ Grid.propTypes = {
   zones: PropTypes.array.isRequired
 };
 
+const getZoneDetails = (appState, zoneName, cards) => {
+  if (!appState.didGameStart) {
+    return 0;
+  }
+
+  if (zoneName === ZONE_PACK) {
+    if (appState.isDecadentDraft) {
+      // Only 1 pick in decadent draft.
+      return `Pick 1 / 1`;
+    } else {
+      return `Pick ${appState.pickNumber} / ${appState.packSize}`
+    }
+  } else {
+    return cards.length;
+  }
+}
+
 const zone = (zoneName, index) => {
   const zone = App.getSortedZone(zoneName);
   const zoneDisplayName = getZoneDisplayName(zoneName);
@@ -24,16 +41,12 @@ const zone = (zoneName, index) => {
   const cards = _.flat(values);
 
   const zoneTitle = zoneDisplayName + (zoneName === ZONE_PACK ? " " + App.state.round : "");
-  const zoneHelper = App.state.didGameStart
-    ? zoneName === ZONE_PACK
-      ? `Pick ${App.state.pickNumber} / ${App.state.packSize}`
-      : cards.length
-    : 0;
+  const zoneDetails = getZoneDetails(App.state, zoneName, cards);
 
   return (
     <div className='zone' key={index}>
       <h1>
-        <Spaced elements={[zoneTitle, zoneHelper]}/>
+        <Spaced elements={[zoneTitle, zoneDetails]}/>
       </h1>
       {cards.map((card, i) =>
         <Card key={i+zoneName+card.name+card.foil} card={card} zoneName={zoneName} />

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import _ from "utils/utils";
 import App from "../app";
 import {getCardSrc, getFallbackSrc} from "../cardimage";
-import {Spaced} from "../utils";
+import Spaced from "../components/Spaced";
 import {ZONE_PACK, getZoneDisplayName} from "../zones";
 
 const Grid = ({zones}) => (

--- a/frontend/src/game/StartPanel.jsx
+++ b/frontend/src/game/StartPanel.jsx
@@ -2,7 +2,8 @@ import React from "react";
 
 import App from "../app";
 import Checkbox from "../components/Checkbox";
-import { Select, toTitleCase } from "../utils";
+import Select from "../components/Select";
+import { toTitleCase } from "../utils";
 
 const StartPanel = () => {
   const gameType = toTitleCase(App.state.game.type);

--- a/frontend/src/game/StartPanel.jsx
+++ b/frontend/src/game/StartPanel.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import App from "../app";
-import { Select, Checkbox, toTitleCase } from "../utils";
-
+import Checkbox from "../components/Checkbox";
+import { Select, toTitleCase } from "../utils";
 
 const StartPanel = () => {
   const gameType = toTitleCase(App.state.game.type);

--- a/frontend/src/game/StartPanel.jsx
+++ b/frontend/src/game/StartPanel.jsx
@@ -43,8 +43,14 @@ const Options = () => {
   const timers = ["Fast", "Moderate", "Slow", "Leisurely"];
   return (
     <span>
-      <Checkbox side="left" link="addBots" text="Fill empty seats with Bots"/>
-      <Checkbox side="left" link="shufflePlayers" text="Random seating"/>
+      {showAddBotsCheckbox()
+        ? <Checkbox side="left" link="addBots" text="Fill empty seats with Bots"/>
+        : null
+      }
+      {showShufflePlayersCheckbox()
+        ? <Checkbox side="left" link="shufflePlayers" text="Random seating"/>
+        : null
+      }
       <div>
         <Checkbox side="left" link="useTimer" text="Timer: "/>
         <Select link="timerLength" opts={timers} disabled={!useTimer}/>
@@ -52,5 +58,15 @@ const Options = () => {
     </span>
   );
 };
+
+const showAddBotsCheckbox = () => {
+  // No need for bots in decadent draft since there's no passing.
+  return !App.state.isDecadentDraft;
+}
+
+const showShufflePlayersCheckbox = () => {
+  // No need to shuffle players in decadent draft because there's no passing.
+  return !App.state.isDecadentDraft;
+}
 
 export default StartPanel;

--- a/frontend/src/lobby/CreatePanel.jsx
+++ b/frontend/src/lobby/CreatePanel.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import _ from "utils/utils";
 import App from "../app";
-import {Checkbox} from "../utils";
+import Checkbox from "../components/Checkbox";
 
 import GameTypes from "./GameTypes";
 import GameOptions from "./GameOptions";

--- a/frontend/src/lobby/CubeList.jsx
+++ b/frontend/src/lobby/CubeList.jsx
@@ -13,7 +13,7 @@ const CubeList = () => {
   return (<div id='cube-list'>
     <div className='column'>
       <div>{`One card per line! (${cubeListLength} cards)`}</div>
-      <TextArea
+      <TextArea className="cube-list"
         placeholder='cube list'
         link='list'
       />

--- a/frontend/src/lobby/CubeList.jsx
+++ b/frontend/src/lobby/CubeList.jsx
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from "react";
 import axios from "axios";
 
-import { Textarea } from "../utils";
+import TextArea from "../components/TextArea";
 import App from "../app";
 
 const CubeList = () => {
@@ -13,7 +13,7 @@ const CubeList = () => {
   return (<div id='cube-list'>
     <div className='column'>
       <div>{`one card per line (${cubeListLength} cards)`}</div>
-      <Textarea
+      <TextArea
         placeholder='cube list'
         link='list'
       />

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -14,21 +14,53 @@ const GameOptions = () => {
 
   switch (`${gamesubtype} ${gametype}`) {
   case "regular draft":
-    return <Regular sets={setsDraft} type={"setsDraft"} />;
+    return <RegularDraft sets={setsDraft} type={"setsDraft"} />;
   case "regular sealed":
-    return <Regular sets={setsSealed} type={"setsSealed"} />;
+    return <RegularSealed sets={setsSealed} type={"setsSealed"} />;
   case "decadent draft":
     return <Decadent sets={setsDraft} type={"setsDraft"} />;
   case "cube draft":
-    return <CubeDraft />;
+    return <CubeDraft/>;
   case "cube sealed":
-    return <CubeSealed />;
+    return <CubeSealed/>;
   case "chaos draft":
-    return <Chaos packsNumber={"chaosDraftPacksNumber"} />;
+    return <ChaosDraft/>
   case "chaos sealed":
-    return <Chaos packsNumber={"chaosSealedPacksNumber"}/>;
+    return <ChaosSealed/>;
   }
 };
+
+const RegularDraft = ({sets, type}) => (
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>Each player starts with {sets.length} booster packs.</p>
+      <p>To begin, each player opens one pack, chooses (drafts) one card, and passes the rest to the next player.</p>
+      <p>That player drafts one card from what's left, passes it, and so on until no cards are left.</p>
+      <p>Then everyone opens their next pack, starting a new round. Packs are passed in alternating directions each round.</p>
+      <p>Once all cards have been drafted, each player builds a deck out of the cards they drafted.</p>
+    </blockquote>
+    <Regular sets={sets} type={type} />
+  </Fragment>
+);
+
+RegularDraft.propTypes = {
+  sets: PropTypes.array,
+  type: PropTypes.string
+}
+
+const RegularSealed = ({sets, type}) => (
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>Each player opens {sets.length} booster packs and builds a deck using any of those cards.</p>
+    </blockquote>
+    <Regular sets={sets} type={type} />
+  </Fragment>
+);
+
+RegularSealed.propTypes = {
+  sets: PropTypes.array,
+  type: PropTypes.string
+}
 
 const Regular = ({ sets, type }) => (
   <Fragment>
@@ -59,7 +91,7 @@ const Decadent = ({ sets, type }) => (
   <Fragment>
     <blockquote className="game-mode-description">
       <p>Also known as "Rich Man's Draft" or "Decadent Sealed".</p>
-      <p>Each round, each player chooses a single card from the pack, discards the rest, then gets a new pack.</p>
+      <p>Like a regular draft except each player chooses one card from the pack, discards the rest, then opens a new pack.</p>
     </blockquote>
     <div>
       Number of packs:{" "}
@@ -80,17 +112,27 @@ Decadent.propTypes = {
 };
 
 const CubeDraft = () => (
-  <div>
-    <CubeList />
-    <CubeOptions />
-  </div>
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>A draft where each pack is a random set of cards from a large pool of cards called the "cube".</p>
+    </blockquote>
+    <div>
+      <CubeList />
+      <CubeOptions />
+    </div>
+  </Fragment>
 );
 
 const CubeSealed = () => (
-  <div>
-    <CubeList />
-    <CubeSealedOptions />
-  </div>
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>Like sealed except each pack is a random set of cards from a large pool of cards called the "cube".</p>
+    </blockquote>
+    <div>
+      <CubeList />
+      <CubeSealedOptions />
+    </div>
+  </Fragment>
 );
 
 const CubeSealedOptions = () => (
@@ -107,6 +149,26 @@ const CubeOptions = () => (
     <Select link="packs" opts={_.seq(12, 1)} />
     {" "}packs
   </div>
+);
+
+const ChaosDraft = () => (
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>A draft where each booster pack is from a random set.</p>
+      <p>Take it up a notch with total chaos to build booster packs where each card in the pack is from a random set!</p>
+    </blockquote>
+    <Chaos packsNumber={"chaosDraftPacksNumber"} />
+  </Fragment>
+);
+
+const ChaosSealed = () => (
+  <Fragment>
+    <blockquote className="game-mode-description">
+      <p>Like sealed except each booster pack is from a random set.</p>
+      <p>Take it up a notch with total chaos to build booster packs where each card in the pack is from a random set!</p>
+    </blockquote>
+    <Chaos packsNumber={"chaosSealedPacksNumber"}/>
+  </Fragment>
 );
 
 const Chaos = ({ packsNumber }) => (

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -28,6 +28,8 @@ const GameOptions = () => {
     return <ChaosDraft/>
   case "chaos sealed":
     return <ChaosSealed/>;
+  default:
+    return null;
   }
 };
 

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -38,7 +38,7 @@ const Regular = ({ sets, type }) => (
       Number of packs:{" "}
       <Select
         value={sets.length}
-        onChange={App._emit("changeSetsNumber", type, false)}
+        onChange={App._emit("changeSetsNumber", type)}
         opts={_.seq(12, 1)} />
     </div>
     <div className="wrapper">
@@ -63,7 +63,7 @@ const Decadent = ({ sets, type }) => (
       Number of packs:{" "}
       <Select
         value={sets.length}
-        onChange={App._emit("changeSetsNumber", type, true)}
+        onChange={App._emit("changeSetsNumber", type)}
         opts={_.seq(60, 36)} />
     </div>
     <div className="wrapper">

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -10,7 +10,7 @@ import Set from "./Set";
 import CubeList from "./CubeList";
 
 const GameOptions = () => {
-  const { setsDraft, setsSealed, gametype, gamesubtype } = App.state;
+  const { setsDraft, setsSealed, setsDecadentDraft, gametype, gamesubtype } = App.state;
 
   switch (`${gamesubtype} ${gametype}`) {
   case "regular draft":
@@ -18,7 +18,7 @@ const GameOptions = () => {
   case "regular sealed":
     return <RegularSealed sets={setsSealed} type={"setsSealed"} />;
   case "decadent draft":
-    return <Decadent sets={setsDraft} type={"setsDraft"} />;
+    return <Decadent sets={setsDecadentDraft} type={"setsDecadentDraft"} />;
   case "cube draft":
     return <CubeDraft/>;
   case "cube sealed":
@@ -101,7 +101,7 @@ const Decadent = ({ sets, type }) => (
         opts={_.seq(60, 36)} />
     </div>
     <div className="wrapper">
-      <Set type={type} selectedSet={sets[0]} index={0} key={0}/>
+      <Set type={type} selectedSet={sets[0]} index={0} key={0} useForAllSets={true} />
     </div>
   </Fragment>
 );

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 
 import _ from "utils/utils";
 import App from "../app";
-import { Checkbox, Select } from "../utils";
+import Checkbox from "../components/Checkbox"
+import { Select } from "../utils";
 
 import Set from "./Set";
 import CubeList from "./CubeList";

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -27,8 +27,6 @@ const GameOptions = () => {
     return <Chaos packsNumber={"chaosDraftPacksNumber"} />;
   case "chaos sealed":
     return <Chaos packsNumber={"chaosSealedPacksNumber"}/>;
-  default:
-    return <Unavailable/>;
   }
 };
 
@@ -132,13 +130,5 @@ const Chaos = ({ packsNumber }) => (
 Chaos.propTypes = {
   packsNumber: PropTypes.number
 };
-
-const Unavailable = () => (
-  <Fragment>
-    <div className="unavailable-game-options">
-      This combination of game mode + game type unavailable!
-    </div>
-  </Fragment>
-);
 
 export default GameOptions;

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -28,7 +28,7 @@ const GameOptions = () => {
   case "chaos sealed":
     return <Chaos packsNumber={"chaosSealedPacksNumber"}/>;
   default:
-    return <Regular sets={setsDraft} type={"setsDraft"} />;
+    return <Unavailable/>;
   }
 };
 
@@ -128,5 +128,13 @@ const Chaos = ({ packsNumber }) => (
 Chaos.propTypes = {
   packsNumber: PropTypes.number
 };
+
+const Unavailable = () => (
+  <Fragment>
+    <div className="unavailable-game-options">
+      This combination of game mode + game type unavailable!
+    </div>
+  </Fragment>
+);
 
 export default GameOptions;

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -7,6 +7,7 @@ import Checkbox from "../components/Checkbox";
 import Select from "../components/Select";
 
 import Set from "./Set";
+import SetReplicated from "./SetReplicated";
 import CubeList from "./CubeList";
 
 const GameOptions = () => {
@@ -101,7 +102,7 @@ const Decadent = ({ sets, type }) => (
         opts={_.seq(60, 36)} />
     </div>
     <div className="wrapper">
-      <Set type={type} selectedSet={sets[0]} index={0} key={0} useForAllSets={true} />
+      <SetReplicated type={type} selectedSet={sets[0]} />
     </div>
   </Fragment>
 );

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 
 import _ from "utils/utils";
 import App from "../app";
-import Checkbox from "../components/Checkbox"
-import { Select } from "../utils";
+import Checkbox from "../components/Checkbox";
+import Select from "../components/Select";
 
 import Set from "./Set";
 import CubeList from "./CubeList";

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -190,7 +190,7 @@ const Chaos = ({ packsNumber }) => (
 );
 
 Chaos.propTypes = {
-  packsNumber: PropTypes.number
+  packsNumber: PropTypes.string
 };
 
 export default GameOptions;

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -17,6 +17,8 @@ const GameOptions = () => {
     return <Regular sets={setsDraft} type={"setsDraft"} />;
   case "regular sealed":
     return <Regular sets={setsSealed} type={"setsSealed"} />;
+  case "decadent draft":
+    return <Decadent sets={setsDraft} type={"setsDraft"} />;
   case "cube draft":
     return <CubeDraft />;
   case "cube sealed":
@@ -31,12 +33,12 @@ const GameOptions = () => {
 };
 
 const Regular = ({ sets, type }) => (
-  <Fragment >
+  <Fragment>
     <div>
       Number of packs:{" "}
       <Select
         value={sets.length}
-        onChange={App._emit("changeSetsNumber", type)}
+        onChange={App._emit("changeSetsNumber", type, false)}
         opts={_.seq(12, 1)} />
     </div>
     <div className="wrapper">
@@ -54,6 +56,26 @@ const Sets = ({ sets, type }) => (
   sets
     .map((set, i) => <Set type={type} selectedSet={set} index={i} key={i} />)
 );
+
+const Decadent = ({ sets, type }) => (
+  <Fragment>
+    <div>
+      Number of packs:{" "}
+      <Select
+        value={sets.length}
+        onChange={App._emit("changeSetsNumber", type, true)}
+        opts={_.seq(60, 36)} />
+    </div>
+    <div className="wrapper">
+      <Set type={type} selectedSet={sets[0]} index={0} key={0} useForAllSets={true} />
+    </div>
+  </Fragment>
+);
+
+Decadent.propTypes = {
+  sets: PropTypes.array,
+  type: PropTypes.string
+};
 
 const CubeDraft = () => (
   <div>

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -59,6 +59,10 @@ const Sets = ({ sets, type }) => (
 
 const Decadent = ({ sets, type }) => (
   <Fragment>
+    <blockquote className="game-mode-description">
+      <p>Also known as "Rich Man's Draft" or "Decadent Sealed".</p>
+      <p>Each round, each player chooses a single card from the pack, discards the rest, then gets a new pack.</p>
+    </blockquote>
     <div>
       Number of packs:{" "}
       <Select

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -71,7 +71,7 @@ const Decadent = ({ sets, type }) => (
         opts={_.seq(60, 36)} />
     </div>
     <div className="wrapper">
-      <Set type={type} selectedSet={sets[0]} index={0} key={0} useForAllSets={true} />
+      <Set type={type} selectedSet={sets[0]} index={0} key={0}/>
     </div>
   </Fragment>
 );

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -42,16 +42,7 @@ const GameTypes = () => {
               type={type}
               key={key}
               isChecked={App.state.gamesubtype === type}
-              onChange={() => {
-                App.save("gamesubtype", type)
-                if (type === "decadent") {
-                  App.state.setsDraft.length = 36;
-                }
-                else if (type === "regular") {
-                  App.state.setsDraft.length = 3;
-                }
-                App._emit("changeSetsNumber", "setsDraft", true)
-              }}
+              onChange={() => App.save("gamesubtype", type)}
             />
           )}
         </span>

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -6,24 +6,38 @@ import App from "../app";
 import { toTitleCase } from "../utils";
 
 const GameTypes = () => {
-  const types = ["draft", "sealed"];
-  const subtypes = ["regular", "cube", "chaos", "decadent"];
+  const gameOptions = {
+    draft: ["regular", "cube", "chaos", "decadent"],
+    sealed: ["regular", "cube", "chaos"]
+  }
+
+  const getAvailableTypes = () => Object.keys(gameOptions);
+  const getAvailableSubTypes = (gameType) => gameOptions[gameType];
   return (
     <div>
       <p>Game type:{" "}
         <span className='connected-container'>
-          {types.map((type, key) =>
+          {getAvailableTypes().map((gameType, key) =>
             <GameType name={"type"}
-              type={type}
+              type={gameType}
               key={key}
-              isChecked={App.state.gametype === type}
-              onChange={() => App.save("gametype", type)}/>
+              isChecked={App.state.gametype === gameType}
+              onChange={() => {
+                App.save("gametype", gameType)
+                const availableSubtypes = getAvailableSubTypes(gameType)
+                if (!availableSubtypes.includes(App.state.gamesubtype)) {
+                  // Reset to first available subtype if the currently-selected
+                  // subtype is not available for the newly-selected type.
+                  App.save("gamesubtype", availableSubtypes[0])
+                }
+              }}
+            />
           )}
         </span>
       </p>
       <p>Game mode:{" "}
         <span className='connected-container'>
-          {subtypes.map((type, key) =>
+          {getAvailableSubTypes(App.state.gametype).map((type, key) =>
             <GameType name={"subtype"}
               type={type}
               key={key}
@@ -37,8 +51,8 @@ const GameTypes = () => {
                   App.state.setsDraft.length = 3;
                 }
                 App._emit("changeSetsNumber", "setsDraft", true)
-              }
-              }/>
+              }}
+            />
           )}
         </span>
       </p>

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 
 import App from "../app";
 
+import { toTitleCase } from "../utils";
+
 const GameTypes = () => {
   const types = ["draft", "sealed"];
   const subtypes = ["regular", "cube", "chaos"];
@@ -42,7 +44,7 @@ const GameType = ({ name, type, isChecked, onChange}) => (
       type='radio'
       value={type}
       onChange={onChange}
-      checked={isChecked}/> {type.toLowerCase().split(" ").map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(" ")}
+      checked={isChecked}/> {toTitleCase(type)}
   </label>
 );
 

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -32,8 +32,11 @@ const GameTypes = () => {
                 App.save("gamesubtype", type)
                 if (type === "decadent") {
                   App.state.setsDraft.length = 36;
-                  App._emit("changeSetsNumber", "setsDraft", true)
                 }
+                else if (type === "regular") {
+                  App.state.setsDraft.length = 3;
+                }
+                App._emit("changeSetsNumber", "setsDraft", true)
               }
               }/>
           )}

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -7,7 +7,7 @@ import { toTitleCase } from "../utils";
 
 const GameTypes = () => {
   const types = ["draft", "sealed"];
-  const subtypes = ["regular", "cube", "chaos"];
+  const subtypes = ["regular", "cube", "chaos", "decadent"];
   return (
     <div>
       <p>Game type:{" "}

--- a/frontend/src/lobby/GameTypes.jsx
+++ b/frontend/src/lobby/GameTypes.jsx
@@ -28,7 +28,14 @@ const GameTypes = () => {
               type={type}
               key={key}
               isChecked={App.state.gamesubtype === type}
-              onChange={() => App.save("gamesubtype", type)}/>
+              onChange={() => {
+                App.save("gamesubtype", type)
+                if (type === "decadent") {
+                  App.state.setsDraft.length = 36;
+                  App._emit("changeSetsNumber", "setsDraft", true)
+                }
+              }
+              }/>
           )}
         </span>
       </p>

--- a/frontend/src/lobby/Header.jsx
+++ b/frontend/src/lobby/Header.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { STRINGS } from "../config";
-import { Spaced } from "../utils";
+import Spaced from "../components/Spaced";
 import App from "../app";
 
 const Header = () => (

--- a/frontend/src/lobby/Set.jsx
+++ b/frontend/src/lobby/Set.jsx
@@ -4,11 +4,17 @@ import PropTypes from "prop-types";
 import App from "../app";
 import { toTitleCase } from "../utils";
 
-const Set = ({ index, selectedSet, type }) => {
+const Set = ({ index, selectedSet, type, useForAllSets=false }) => {
   const onSetChange = (e) => {
     const chosenSet = e.currentTarget.value;
     let sets = App.state[type];
-    sets[index] = chosenSet;
+    if (!useForAllSets) {
+      sets[index] = chosenSet;
+    } else {
+      for (let i = 0; i < sets.length; i++) {
+        sets[i] = chosenSet;
+      }
+    }
     App.save(type, App.state[type]);
   };
   let groups = [];
@@ -34,7 +40,8 @@ const Set = ({ index, selectedSet, type }) => {
 Set.propTypes = {
   index: PropTypes.number,
   selectedSet: PropTypes.string,
-  type: PropTypes.string
+  type: PropTypes.string,
+  useForAllSets: PropTypes.bool
 };
 
 export default Set;

--- a/frontend/src/lobby/Set.jsx
+++ b/frontend/src/lobby/Set.jsx
@@ -4,9 +4,17 @@ import PropTypes from "prop-types";
 import App from "../app";
 import { toTitleCase } from "../utils";
 
-const Set = ({ index, selectedSet, type }) => {
+const Set = ({ index, selectedSet, type, useForAllSets=false }) => {
   const onSetChange = (e) => {
-    App.state[type][index] = e.currentTarget.value;
+    const chosenSet = e.currentTarget.value;
+    let sets = App.state[type];
+    if (!useForAllSets) {
+      sets[index] = chosenSet;
+    } else {
+      for (let i = 0; i < sets.length; i++) {
+        sets[i] = chosenSet;
+      }
+    }
     App.save(type, App.state[type]);
   };
   let groups = [];
@@ -32,7 +40,8 @@ const Set = ({ index, selectedSet, type }) => {
 Set.propTypes = {
   index: PropTypes.number,
   selectedSet: PropTypes.string,
-  type: PropTypes.string
+  type: PropTypes.string,
+  useForAllSets: PropTypes.bool
 };
 
 export default Set;

--- a/frontend/src/lobby/Set.jsx
+++ b/frontend/src/lobby/Set.jsx
@@ -34,8 +34,7 @@ const Set = ({ index, selectedSet, type }) => {
 Set.propTypes = {
   index: PropTypes.number,
   selectedSet: PropTypes.string,
-  type: PropTypes.string,
-  useForAllSets: PropTypes.bool
+  type: PropTypes.string
 };
 
 export default Set;

--- a/frontend/src/lobby/Set.jsx
+++ b/frontend/src/lobby/Set.jsx
@@ -4,17 +4,11 @@ import PropTypes from "prop-types";
 import App from "../app";
 import { toTitleCase } from "../utils";
 
-const Set = ({ index, selectedSet, type, useForAllSets=false }) => {
+const Set = ({ index, selectedSet, type }) => {
   const onSetChange = (e) => {
     const chosenSet = e.currentTarget.value;
     let sets = App.state[type];
-    if (!useForAllSets) {
-      sets[index] = chosenSet;
-    } else {
-      for (let i = 0; i < sets.length; i++) {
-        sets[i] = chosenSet;
-      }
-    }
+    sets[index] = chosenSet;
     App.save(type, App.state[type]);
   };
   let groups = [];

--- a/frontend/src/lobby/SetChoices.jsx
+++ b/frontend/src/lobby/SetChoices.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import App from "../app";
+import { toTitleCase } from "../utils";
+
+
+const SetChoices = () => {
+  let groups = [];
+  for (let setType in App.state.availableSets) {
+    const allSets = App.state.availableSets[setType];
+    let options = [];
+    allSets.forEach(({ code, name }) => {
+      options.push(
+        <option value={code} key={code}>{name}</option>
+      );
+    });
+    groups.push(
+      <optgroup label={toTitleCase(setType, "_")} key={setType}>{options}</optgroup>
+    );
+  }
+  return groups;
+}
+
+export default SetChoices;

--- a/frontend/src/lobby/SetReplicated.jsx
+++ b/frontend/src/lobby/SetReplicated.jsx
@@ -4,24 +4,27 @@ import PropTypes from "prop-types";
 import App from "../app";
 import SetChoices from "./SetChoices";
 
-const Set = ({ index, selectedSet, type }) => {
+const SetReplicated = ({ selectedSet, type }) => {
+  // A single dropdown which is used to fill an entire array
+  // of sets with the same selection.
   const onSetChange = (e) => {
     const chosenSet = e.currentTarget.value;
     let sets = App.state[type];
-    sets[index] = chosenSet;
+    for (let i = 0; i < sets.length; i++) {
+      sets[i] = chosenSet;
+    }
     App.save(type, App.state[type]);
   };
   return (
-    <select value={selectedSet} onChange={onSetChange} key={index}>
+    <select value={selectedSet} onChange={onSetChange} key={0}>
       <SetChoices/>
     </select>
   );
 };
 
-Set.propTypes = {
-  index: PropTypes.number,
+SetReplicated.propTypes = {
   selectedSet: PropTypes.string,
   type: PropTypes.string
 };
 
-export default Set;
+export default SetReplicated;

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,21 @@
+const capitalize = (word) => {
+  if (!word || typeof word !== "string") {
+    return "";
+  }
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+};
+
+const toTitleCase = (sentence, separator=" ") => {
+  if (!sentence || typeof sentence !== "string") {
+    return "";
+  }
+
+  const words = sentence.split(separator);
+  const capitalized = words.map(capitalize);
+  return capitalized.join(separator);
+};
+
+module.exports = {
+  capitalize,
+  toTitleCase
+};

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,9 +1,4 @@
-const capitalize = (word) => {
-  if (!word || typeof word !== "string") {
-    return "";
-  }
-  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-};
+const capitalize = require("lodash/capitalize");
 
 const toTitleCase = (sentence, separator=" ") => {
   if (!sentence || typeof sentence !== "string") {
@@ -16,6 +11,5 @@ const toTitleCase = (sentence, separator=" ") => {
 };
 
 module.exports = {
-  capitalize,
   toTitleCase
 };

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -1,26 +1,3 @@
-import React from "react";
-import PropTypes from "prop-types";
-
-import App from "./app";
-
-/**
- * Utils offers a list of "connected" tools
- * through a "link" prop to connect to the app state
- */
-
-export const Textarea = ({link, ...rest}) => (
-  <textarea
-    style={ {"overflowY": "scroll", "height": "150px"}}
-    onChange=
-      { (e) => { App.save("list", e.currentTarget.value); } }
-    value={App.state[link]}
-    {...rest} />
-);
-
-Textarea.propTypes = {
-  link: PropTypes.string
-};
-
 //TODO: check if lodash can do it
 export const toTitleCase = (string="", separator=" ") =>
   string.split(separator)

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -8,29 +8,6 @@ import App from "./app";
  * through a "link" prop to connect to the app state
  */
 
-export const Select = ({
-  link,
-  opts,
-  onChange = (e) => { App.save(link, e.currentTarget.value); },
-  value = App.state[link],
-  ...rest}) => (
-  <select
-    onChange={onChange}
-    value={value}
-    {...rest}>
-    {opts.map((opt, index) =>
-      <option key={index}>{opt}</option>
-    )}
-  </select>
-);
-
-Select.propTypes = {
-  link: PropTypes.string,
-  onChange: PropTypes.func,
-  value: PropTypes.any,
-  opts: PropTypes.array
-};
-
 export const Textarea = ({link, ...rest}) => (
   <textarea
     style={ {"overflowY": "scroll", "height": "150px"}}

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -8,27 +8,6 @@ import App from "./app";
  * through a "link" prop to connect to the app state
  */
 
-export const Checkbox = ({link, text, side, onChange, ...rest}) => (
-  <div>
-    {side === "right" ? text : ""}
-    <input
-      {...rest}
-      type="checkbox"
-      onChange={onChange || function (e) {
-        App.save(link, e.currentTarget.checked);
-      }}
-      checked={App.state[link]}/>
-    {side === "left" ? text : ""}
-  </div>
-);
-
-Checkbox.propTypes = {
-  link: PropTypes.string,
-  text: PropTypes.string,
-  side: PropTypes.string,
-  onChange: PropTypes.func
-};
-
 export const Spaced = ({elements}) => (
   elements
     .map((x, index) => <span key={index}>{x}</span>)

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -8,16 +8,6 @@ import App from "./app";
  * through a "link" prop to connect to the app state
  */
 
-export const Spaced = ({elements}) => (
-  elements
-    .map((x, index) => <span key={index}>{x}</span>)
-    .reduce((prev, curr) => [
-      prev,
-      <span key = {prev+curr} className = 'spacer-dot' />,
-      curr
-    ])
-);
-
 export const Select = ({
   link,
   opts,

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -1,4 +1,0 @@
-//TODO: check if lodash can do it
-export const toTitleCase = (string="", separator=" ") =>
-  string.split(separator)
-    .reduce((result, word) => `${result} ${word.charAt(0).toUpperCase()+word.slice(1).toLowerCase()}`, "");

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -627,3 +627,11 @@ input[type="checkbox"], input[type="radio"] {
   color: red;
   font-weight: bold;
 }
+
+.game-mode-description {
+  background: #ddd;
+  border-left: 5px solid #bbb;
+  margin: 0.5em 10px;
+  padding: 1px 1px 1px 10px;
+  font-style: italic;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -622,3 +622,8 @@ input[type="checkbox"], input[type="radio"] {
   display: flex;
   flex-direction: column;
 }
+
+.unavailable-game-options {
+  color: red;
+  font-weight: bold;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -623,15 +623,9 @@ input[type="checkbox"], input[type="radio"] {
   flex-direction: column;
 }
 
-.unavailable-game-options {
-  color: red;
-  font-weight: bold;
-}
-
 .game-mode-description {
   background: #ddd;
   border-left: 5px solid #bbb;
-  margin: 0.5em 10px;
   padding: 1px 1px 1px 10px;
   font-style: italic;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -630,3 +630,8 @@ input[type="checkbox"], input[type="radio"] {
   padding: 1px 1px 1px 10px;
   font-style: italic;
 }
+
+.cube-list {
+  overflow-y: "scroll";
+  height: 150px;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -626,6 +626,7 @@ input[type="checkbox"], input[type="radio"] {
 .game-mode-description {
   background: #ddd;
   border-left: 5px solid #bbb;
+  margin-left: 0px;
   padding: 1px 1px 1px 10px;
   font-style: italic;
 }

--- a/frontend/test/utils.spec.js
+++ b/frontend/test/utils.spec.js
@@ -1,0 +1,44 @@
+const {describe, it} = require("mocha");
+const assert = require("assert");
+const {capitalize, toTitleCase} = require("../src/utils");
+
+describe("Acceptance tests for frontend utils", () => {
+  it("capitalize() should capitalize a single word", () => {
+    assert(capitalize("") === "");
+    assert(capitalize(0) === "");
+    assert(capitalize({}) === "");
+
+    assert(capitalize("draft") === "Draft");
+    assert(capitalize("Draft") === "Draft");
+    assert(capitalize("DRAFT") === "Draft");
+    assert(capitalize("draft") === "Draft");
+
+    assert(capitalize("cube draft") === "Cube draft");
+    assert(capitalize("CUBE DRAFT") === "Cube draft");
+  });
+  it("toTitleCase() should capitalize each word", () => {
+    assert(toTitleCase("") === "");
+    assert(toTitleCase(0) === "");
+    assert(toTitleCase({}) === "");
+
+    assert(toTitleCase("draft") === "Draft");
+    assert(toTitleCase("Draft") === "Draft");
+    assert(toTitleCase("DRAFT") === "Draft");
+    assert(toTitleCase("draft") === "Draft");
+
+    assert(toTitleCase("cube draft") === "Cube Draft");
+    assert(toTitleCase("CUBE DRAFT") === "Cube Draft");
+
+    assert(toTitleCase("cube_draft") === "Cube_draft");
+    assert(toTitleCase("CUBE_DRAFT") === "Cube_draft");
+    assert(toTitleCase("cube_draft", "_") === "Cube_Draft");
+    assert(toTitleCase("CUBE_DRAFT", "_") === "Cube_Draft");
+
+    assert(toTitleCase("longer sentence of wordiness") === "Longer Sentence Of Wordiness");
+    assert(toTitleCase("LONGER SENTENCE OF WORDINESS") === "Longer Sentence Of Wordiness");
+    assert(toTitleCase("longer_sentence_of_wordiness") === "Longer_sentence_of_wordiness");
+    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS") === "Longer_sentence_of_wordiness");
+    assert(toTitleCase("longer_sentence_of_wordiness", "_") === "Longer_Sentence_Of_Wordiness");
+    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS", "_") === "Longer_Sentence_Of_Wordiness");
+  });
+});

--- a/frontend/test/utils.spec.js
+++ b/frontend/test/utils.spec.js
@@ -1,21 +1,8 @@
 const {describe, it} = require("mocha");
 const assert = require("assert");
-const {capitalize, toTitleCase} = require("./../src/utils");
+const {toTitleCase} = require("./../src/utils");
 
 describe("Acceptance tests for frontend utils", () => {
-  it("capitalize() should capitalize a single word", () => {
-    assert(capitalize("") === "");
-    assert(capitalize(0) === "");
-    assert(capitalize({}) === "");
-
-    assert(capitalize("draft") === "Draft");
-    assert(capitalize("Draft") === "Draft");
-    assert(capitalize("DRAFT") === "Draft");
-    assert(capitalize("draft") === "Draft");
-
-    assert(capitalize("cube draft") === "Cube draft");
-    assert(capitalize("CUBE DRAFT") === "Cube draft");
-  });
   it("toTitleCase() should capitalize each word", () => {
     assert(toTitleCase("") === "");
     assert(toTitleCase(0) === "");

--- a/frontend/test/utils.spec.js
+++ b/frontend/test/utils.spec.js
@@ -1,44 +1,44 @@
-const {describe, it} = require("mocha");
-const assert = require("assert");
-const {capitalize, toTitleCase} = require("../src/utils");
+// const {describe, it} = require("mocha");
+// const assert = require("assert");
+// const {capitalize, toTitleCase} = require("./../src/utils");
 
-describe("Acceptance tests for frontend utils", () => {
-  it("capitalize() should capitalize a single word", () => {
-    assert(capitalize("") === "");
-    assert(capitalize(0) === "");
-    assert(capitalize({}) === "");
+// describe("Acceptance tests for frontend utils", () => {
+//   it("capitalize() should capitalize a single word", () => {
+//     assert(capitalize("") === "");
+//     assert(capitalize(0) === "");
+//     assert(capitalize({}) === "");
 
-    assert(capitalize("draft") === "Draft");
-    assert(capitalize("Draft") === "Draft");
-    assert(capitalize("DRAFT") === "Draft");
-    assert(capitalize("draft") === "Draft");
+//     assert(capitalize("draft") === "Draft");
+//     assert(capitalize("Draft") === "Draft");
+//     assert(capitalize("DRAFT") === "Draft");
+//     assert(capitalize("draft") === "Draft");
 
-    assert(capitalize("cube draft") === "Cube draft");
-    assert(capitalize("CUBE DRAFT") === "Cube draft");
-  });
-  it("toTitleCase() should capitalize each word", () => {
-    assert(toTitleCase("") === "");
-    assert(toTitleCase(0) === "");
-    assert(toTitleCase({}) === "");
+//     assert(capitalize("cube draft") === "Cube draft");
+//     assert(capitalize("CUBE DRAFT") === "Cube draft");
+//   });
+//   it("toTitleCase() should capitalize each word", () => {
+//     assert(toTitleCase("") === "");
+//     assert(toTitleCase(0) === "");
+//     assert(toTitleCase({}) === "");
 
-    assert(toTitleCase("draft") === "Draft");
-    assert(toTitleCase("Draft") === "Draft");
-    assert(toTitleCase("DRAFT") === "Draft");
-    assert(toTitleCase("draft") === "Draft");
+//     assert(toTitleCase("draft") === "Draft");
+//     assert(toTitleCase("Draft") === "Draft");
+//     assert(toTitleCase("DRAFT") === "Draft");
+//     assert(toTitleCase("draft") === "Draft");
 
-    assert(toTitleCase("cube draft") === "Cube Draft");
-    assert(toTitleCase("CUBE DRAFT") === "Cube Draft");
+//     assert(toTitleCase("cube draft") === "Cube Draft");
+//     assert(toTitleCase("CUBE DRAFT") === "Cube Draft");
 
-    assert(toTitleCase("cube_draft") === "Cube_draft");
-    assert(toTitleCase("CUBE_DRAFT") === "Cube_draft");
-    assert(toTitleCase("cube_draft", "_") === "Cube_Draft");
-    assert(toTitleCase("CUBE_DRAFT", "_") === "Cube_Draft");
+//     assert(toTitleCase("cube_draft") === "Cube_draft");
+//     assert(toTitleCase("CUBE_DRAFT") === "Cube_draft");
+//     assert(toTitleCase("cube_draft", "_") === "Cube_Draft");
+//     assert(toTitleCase("CUBE_DRAFT", "_") === "Cube_Draft");
 
-    assert(toTitleCase("longer sentence of wordiness") === "Longer Sentence Of Wordiness");
-    assert(toTitleCase("LONGER SENTENCE OF WORDINESS") === "Longer Sentence Of Wordiness");
-    assert(toTitleCase("longer_sentence_of_wordiness") === "Longer_sentence_of_wordiness");
-    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS") === "Longer_sentence_of_wordiness");
-    assert(toTitleCase("longer_sentence_of_wordiness", "_") === "Longer_Sentence_Of_Wordiness");
-    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS", "_") === "Longer_Sentence_Of_Wordiness");
-  });
-});
+//     assert(toTitleCase("longer sentence of wordiness") === "Longer Sentence Of Wordiness");
+//     assert(toTitleCase("LONGER SENTENCE OF WORDINESS") === "Longer Sentence Of Wordiness");
+//     assert(toTitleCase("longer_sentence_of_wordiness") === "Longer_sentence_of_wordiness");
+//     assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS") === "Longer_sentence_of_wordiness");
+//     assert(toTitleCase("longer_sentence_of_wordiness", "_") === "Longer_Sentence_Of_Wordiness");
+//     assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS", "_") === "Longer_Sentence_Of_Wordiness");
+//   });
+// });

--- a/frontend/test/utils.spec.js
+++ b/frontend/test/utils.spec.js
@@ -1,44 +1,44 @@
-// const {describe, it} = require("mocha");
-// const assert = require("assert");
-// const {capitalize, toTitleCase} = require("./../src/utils");
+const {describe, it} = require("mocha");
+const assert = require("assert");
+const {capitalize, toTitleCase} = require("./../src/utils");
 
-// describe("Acceptance tests for frontend utils", () => {
-//   it("capitalize() should capitalize a single word", () => {
-//     assert(capitalize("") === "");
-//     assert(capitalize(0) === "");
-//     assert(capitalize({}) === "");
+describe("Acceptance tests for frontend utils", () => {
+  it("capitalize() should capitalize a single word", () => {
+    assert(capitalize("") === "");
+    assert(capitalize(0) === "");
+    assert(capitalize({}) === "");
 
-//     assert(capitalize("draft") === "Draft");
-//     assert(capitalize("Draft") === "Draft");
-//     assert(capitalize("DRAFT") === "Draft");
-//     assert(capitalize("draft") === "Draft");
+    assert(capitalize("draft") === "Draft");
+    assert(capitalize("Draft") === "Draft");
+    assert(capitalize("DRAFT") === "Draft");
+    assert(capitalize("draft") === "Draft");
 
-//     assert(capitalize("cube draft") === "Cube draft");
-//     assert(capitalize("CUBE DRAFT") === "Cube draft");
-//   });
-//   it("toTitleCase() should capitalize each word", () => {
-//     assert(toTitleCase("") === "");
-//     assert(toTitleCase(0) === "");
-//     assert(toTitleCase({}) === "");
+    assert(capitalize("cube draft") === "Cube draft");
+    assert(capitalize("CUBE DRAFT") === "Cube draft");
+  });
+  it("toTitleCase() should capitalize each word", () => {
+    assert(toTitleCase("") === "");
+    assert(toTitleCase(0) === "");
+    assert(toTitleCase({}) === "");
 
-//     assert(toTitleCase("draft") === "Draft");
-//     assert(toTitleCase("Draft") === "Draft");
-//     assert(toTitleCase("DRAFT") === "Draft");
-//     assert(toTitleCase("draft") === "Draft");
+    assert(toTitleCase("draft") === "Draft");
+    assert(toTitleCase("Draft") === "Draft");
+    assert(toTitleCase("DRAFT") === "Draft");
+    assert(toTitleCase("draft") === "Draft");
 
-//     assert(toTitleCase("cube draft") === "Cube Draft");
-//     assert(toTitleCase("CUBE DRAFT") === "Cube Draft");
+    assert(toTitleCase("cube draft") === "Cube Draft");
+    assert(toTitleCase("CUBE DRAFT") === "Cube Draft");
 
-//     assert(toTitleCase("cube_draft") === "Cube_draft");
-//     assert(toTitleCase("CUBE_DRAFT") === "Cube_draft");
-//     assert(toTitleCase("cube_draft", "_") === "Cube_Draft");
-//     assert(toTitleCase("CUBE_DRAFT", "_") === "Cube_Draft");
+    assert(toTitleCase("cube_draft") === "Cube_draft");
+    assert(toTitleCase("CUBE_DRAFT") === "Cube_draft");
+    assert(toTitleCase("cube_draft", "_") === "Cube_Draft");
+    assert(toTitleCase("CUBE_DRAFT", "_") === "Cube_Draft");
 
-//     assert(toTitleCase("longer sentence of wordiness") === "Longer Sentence Of Wordiness");
-//     assert(toTitleCase("LONGER SENTENCE OF WORDINESS") === "Longer Sentence Of Wordiness");
-//     assert(toTitleCase("longer_sentence_of_wordiness") === "Longer_sentence_of_wordiness");
-//     assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS") === "Longer_sentence_of_wordiness");
-//     assert(toTitleCase("longer_sentence_of_wordiness", "_") === "Longer_Sentence_Of_Wordiness");
-//     assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS", "_") === "Longer_Sentence_Of_Wordiness");
-//   });
-// });
+    assert(toTitleCase("longer sentence of wordiness") === "Longer Sentence Of Wordiness");
+    assert(toTitleCase("LONGER SENTENCE OF WORDINESS") === "Longer Sentence Of Wordiness");
+    assert(toTitleCase("longer_sentence_of_wordiness") === "Longer_sentence_of_wordiness");
+    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS") === "Longer_sentence_of_wordiness");
+    assert(toTitleCase("longer_sentence_of_wordiness", "_") === "Longer_Sentence_Of_Wordiness");
+    assert(toTitleCase("LONGER_SENTENCE_OF_WORDINESS", "_") === "Longer_Sentence_Of_Wordiness");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   "scripts": {
     "start": "node scripts/run",
     "start-dev": "npm run watch & npm run nodemon",
+    "start-debug": "npm run watch & npm run nodemon:debug",
     "build": "webpack --config webpack.prod.js",
     "watch": "webpack --config webpack.dev.js --watch -d --display-error-details",
     "nodemon": "nodemon ./app.js -e html,js --ignore built --ignore frontend",
+    "nodemon:debug": "nodemon --inspect-brk=1338 ./app.js -e html,js --ignore built --ignore frontend",
     "lint": "eslint --ignore-path .gitignore .",
     "pretest": "npm run lint",
     "test": "mocha --reporter spec --exit \"./{,!(node_modules)/**/}*.spec.js\"",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,7 +22,7 @@ module.exports = {
       cache: false
     }),
     new CopyWebpackPlugin([
-      { from: "frontend", ignore: ["*.tpl", "src/**/*"] }
+      { from: "frontend", ignore: ["*.tpl", "src/**/*", "test/**/*"] }
     ], {
       copyUnmodified: true
     }),
@@ -44,8 +44,8 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: [
-          "./node_modules",
-          "./frontend/test"
+          /node_modules/,
+          /\.spec\.js$/
         ],
         use: {
           loader: "babel-loader",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,7 +43,7 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
+        exclude: /(node_modules|\.spec\.js$)/,
         use: {
           loader: "babel-loader",
           options: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,7 +43,10 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /(node_modules|\.spec\.js$)/,
+        exclude: [
+          "./node_modules",
+          "./frontend/test"
+        ],
         use: {
           loader: "babel-loader",
           options: {


### PR DESCRIPTION
# Summary

Fix #919 

Adds a "Decadent" game mode to address the request in https://github.com/dr4fters/dr4ft/issues/919. As described in that issue, it's also known as "Rich Man's Draft" or "Decadent Sealed".

This is essentially a draft where each person picks only one card from a pack, discards the rest, and opens a new pack until all packs have been drafted. As such, it's implemented as a draft where if you would pass, a new round is started instead.

![image](https://user-images.githubusercontent.com/1089924/80289580-2a6ab580-86f4-11ea-9ce3-ce55e34f8978.png)

# Details
* Only works with the "Draft" game type.
* Can choose as low as 36 or as high as 60 packs to draft from.
* All packs must be from the same set.
    * Implemented this way because editing 36+ set selection dropdowns manually is tedious.
* Refactored `frontend/src/utils.jsx` to split out common components into the `frontend/src/components/` directory.
    * Extracted these components: `Checkbox`, `Spaced`, `Select`, `TextArea`.
    * Fixed in TextArea.jsx `App.save("list", ...)` --> `App.save(link, ...)`
    * Changed `utils.jsx` --> `utils.js`
* Added `frontend/test/` for tests of `toTitleCase()` in utils.js.
* Created `SetReplicated` component which is like the `Set` component except it fills the entire set array with the same set instead of handling one index of the array.
  * Open to suggestions for a better name for this component.
  * Factored out `SetChoices` which is reused in `Set` and `SetReplicated`.