### PR TITLE
Add check to version metadata when comparing mtgjson version

### DIFF
--- a/scripts/download_allsets.js
+++ b/scripts/download_allsets.js
@@ -14,7 +14,7 @@ const versionURL = "https://www.mtgjson.com/files/version.json";
 const setsVersion = path.join(getDataDir(), "version.json");
 
 const isVersionNewer = ({ version: remoteVer }, { version: currentVer }) => (
-  semver.gt(remoteVer, currentVer)
+  semver.compareBuild(remoteVer, currentVer) > -1
 );
 
 const isVersionUpToDate = () => (


### PR DESCRIPTION
As [MTGJson](https:/mtgjson.com/) versioning also uses metadata, we need to check them in order to know if we need to update our DB. 

This PR changes the version check from strict (without metadata) to metadata check (with the function compareBuild)