### PR TITLE
reset pack after autopick

### DIFF
--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -13,6 +13,7 @@ const events = {
   add(card) {
     const zoneName = App.state.side ? ZONE_SIDEBOARD : ZONE_MAIN;
     App.state.gameState.add(zoneName, card);
+    App.state.gameState.resetPack();
     App.update();
   },
   click(zoneName, card, e) {


### PR DESCRIPTION
This adds a reset pack for the autopick event on frontend. 

It's related with the #1017 issue but do not solve all of it.