### PR TITLE
ISSUE-1034: Fix sets flickering and not remembered

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -175,9 +175,14 @@ let App = {
       // Default sets to the latest set.
       const defaultSetCode = App.state.latestSet.code;
       const replicateDefaultSet = (desiredLength) => times(desiredLength, constant(defaultSetCode));
-      App.state.setsSealed = replicateDefaultSet(6);
-      App.state.setsDraft = replicateDefaultSet(3);
-      App.state.setsDecadentDraft = replicateDefaultSet(36);
+      const initializeIfEmpty = (sets, desiredLength) => {
+        if (sets.length === 0) {
+          sets = replicateDefaultSet(desiredLength);
+        }
+      };
+      initializeIfEmpty(App.state.setsSealed, 6);
+      initializeIfEmpty(App.state.setsDraft, 3);
+      initializeIfEmpty(App.state.setsDecadentDraft, 36);
     }
     App.update();
   },


### PR DESCRIPTION
# Summary

Fix issue https://github.com/dr4fters/dr4ft/issues/1034 introduced by https://github.com/dr4fters/dr4ft/pull/990 where:

1. The set dropdowns momentarily flicker back to the default set (currently Ikoria) when creating a game room if a set other than the default was chosen.
2. When returning to the Lobby page, rather than remembering set selections all the sets were reset to the default.