### PR TITLE
fix hash lenght

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -250,7 +250,7 @@ const getBoosterRulesVersion = () => {
       return "";
     }
   }
-  return boosterRules.repoHash.substring(0,8);
+  return boosterRules.repoHash.substring(0,7);
 };
 
 const saveBoosterRules = (boosterRules) => {


### PR DESCRIPTION
Truncated GitHub hashes for commits are 7 digits, not 8.