### PR TITLE
Do not always add a colorless card

### DIFF
--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -80,7 +80,6 @@ function getRandomCardsWithColorBalance({cardsByColor, cards}, numberOfCardsToPi
     "U": cardsByColor["U"].length * numberOfCardsToPick - n,
     "R": cardsByColor["R"].length * numberOfCardsToPick - n,
     "G": cardsByColor["G"].length * numberOfCardsToPick - n,
-    "c": (cardsByColor["c"] || []).length * numberOfCardsToPick,
   };
   const total = Object.values(nums).reduce((total, num) => total + num);
   while (ret.size < numberOfCardsToPick) {


### PR DESCRIPTION
## Fixes #
No issue yet :D

## Description of your changes
This PR tends to solve the colorless card absurd probability representation that I've noticed in boosters when we generate a balanced by color pack.  
I just delete the auto include colorless card.

## Screenshots


