### PR TITLE
update DB in another process

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,11 +6,10 @@ const helmet = require("helmet");
 const fileUpload = require("express-fileupload");
 const cors = require("cors");
 const bodyParser = require("body-parser");
+const {spawn} = require("child_process");
 const logger = require("./backend/logger");
 const router = require("./backend/router");
 const apiRouter = require("./backend/api/");
-const allSets = require("./scripts/download_allsets");
-const downloadBoosterRules = require("./scripts/download_booster_rules");
 const {app: config, version} = require("./config");
 const app = express();
 require("./backend/data-watch");
@@ -27,12 +26,12 @@ app.use(express.static("built"));
 app.use("/api", apiRouter);
 
 // Download Allsets.json if there's a new one and make the card DB
-allSets.download();
+spawn("node", ["scripts/download_allsets.js"], { stdio: "inherit" });
 
 // Schedule check of a new sets and new boosterRules every hour
 schedule.scheduleJob("0 * * * *", () => {
-  allSets.download();
-  downloadBoosterRules();
+  spawn("node", ["scripts/download_allsets.js"], { stdio: "inherit" });
+  spawn("node", ["scripts/download_booster_rules.js"], { stdio: "inherit" });
 });
 
 // Create server

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ app.use("/api", apiRouter);
 
 // Download Allsets.json if there's a new one and make the card DB
 spawn("node", ["scripts/download_allsets.js"], { stdio: "inherit" });
+spawn("node", ["scripts/download_booster_rules.js"], { stdio: "inherit" });
 
 // Schedule check of a new sets and new boosterRules every hour
 schedule.scheduleJob("0 * * * *", () => {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nodemon:debug": "nodemon --inspect-brk=1338 ./app.js -e html,js --ignore built --ignore frontend",
     "lint": "eslint --ignore-path .gitignore .",
     "pretest": "npm run lint",
-    "test": "mocha --reporter spec --exit \"./{,!(node_modules)/**/}*.spec.js\"",
+    "test": "npm run postinstall && mocha --reporter spec --exit \"./{,!(node_modules)/**/}*.spec.js\"",
     "postinstall": " npm run download_allsets && npm run download_booster_rules && webpack --config webpack.prod.js",
     "update_database": "node scripts/update_database ",
     "download_allsets": "node scripts/download_allsets",

--- a/scripts/download_allsets.js
+++ b/scripts/download_allsets.js
@@ -4,7 +4,6 @@ const https = require("https");
 const unzip = require("unzipper");
 const semver = require("semver");
 const updateDatabase = require("./update_database");
-const downloadBoosterRules = require("./download_booster_rules");
 const logger = require("../backend/logger");
 const { refresh: refreshVersion } = require("../backend/mtgjson");
 const {getDataDir} = require("../backend/data");
@@ -76,7 +75,6 @@ const download = async () => {
     logger.info("Update DB finished");
     fs.writeFileSync(setsVersion, version);
     refreshVersion();
-    await downloadBoosterRules();
   } else {
     logger.info("AllSets.json is up to date");
   }

--- a/scripts/download_allsets.js
+++ b/scripts/download_allsets.js
@@ -12,6 +12,8 @@ const mtgJsonURL = "https://www.mtgjson.com/files/AllSetFiles.zip";
 const versionURL = "https://www.mtgjson.com/files/version.json";
 const setsVersion = path.join(getDataDir(), "version.json");
 
+const setsDataDir = path.join(getDataDir(), "sets");
+
 const isVersionNewer = ({ version: remoteVer }, { version: currentVer }) => (
   semver.compareBuild(remoteVer, currentVer) > 0
 );
@@ -50,16 +52,7 @@ const fetchZip = () => (
     https.get(mtgJsonURL, response => {
       logger.info("Updating AllSets.json");
       response
-        .pipe(unzip.Parse())
-        .on("entry", (entry) => {
-          const setsDataDir = path.join(getDataDir(), "sets");
-          if (!fs.existsSync(setsDataDir)) {
-            fs.mkdirSync(setsDataDir);
-          }
-          const file = fs.createWriteStream(path.join(setsDataDir, `${entry.path}`));
-          entry.pipe(file)
-            .on("finish", file.close);
-        })
+        .pipe(unzip.Extract({ path: setsDataDir, concurrency: 4 }))
         .on("finish", resolve)
         .on("error", reject);
     });

--- a/scripts/download_booster_rules.js
+++ b/scripts/download_booster_rules.js
@@ -1,4 +1,3 @@
-const fs = require("fs");
 const axios = require("axios");
 const logger = require("../backend/logger");
 const {getBoosterRulesVersion, getCardByUuid, getSet, saveBoosterRules} = require("../backend/data");

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,6 +1,6 @@
-const spawn = require("child_process").spawn
+const spawn = require("child_process").spawn;
 
-;(function run() {
+(function run() {
   spawn("node", ["app.js"], { stdio: "inherit" })
     .on("close", run);
 })();


### PR DESCRIPTION
## Fixes #
Fixes the problem of playing when an update of the DB is made. As all DB actions are still synchronized and an update may take couple 10s of seconds, when an update occurs it provokes a big latency for the players. When a DB updates, the server will not respond to players until the update completed, this leads to "game crashed feeling" from the drafters as during the time taken by the update to complete, they lost time and some picks may have been "autopicked". 

## Description of your changes
Move all the scheduled updates to a new node process. Doing so the update will not affect the players. The update will still have an impact on the current process given that we use a "data watch"


## Screenshots


