### PR TITLE
fix booster rules version

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -250,7 +250,7 @@ const getBoosterRulesVersion = () => {
       return "";
     }
   }
-  return boosterRules.repoHash.substring(0,7);
+  return boosterRules.repoHash;
 };
 
 const saveBoosterRules = (boosterRules) => {

--- a/frontend/src/lobby/Version.jsx
+++ b/frontend/src/lobby/Version.jsx
@@ -19,7 +19,7 @@ const Version = ({version, MTGJSONVersion, boosterRulesVersion}) => {
         v{MTGJSONVersion.version}
       </a> ({MTGJSONVersion.date}) and <a href={"https://github.com/taw/magic-sealed-data"}>Magic Sealed Data</a> {" "}
         booster rules{" "}
-      commit <a href={`https://github.com/taw/magic-sealed-data/commit/${boosterRulesVersion}`}>{boosterRulesVersion}</a>
+      commit <a href={`https://github.com/taw/magic-sealed-data/commit/${boosterRulesVersion}`}>{boosterRulesVersion.substring(0,7)}</a>
     </p>
   );
 };

--- a/scripts/download_booster_rules.js
+++ b/scripts/download_booster_rules.js
@@ -9,12 +9,14 @@ async function fetch() {
   logger.info("Checking boosterRules repository");
   const repo = await axios.get(REPO_URL);
   const sha = repo.data.object.sha;
-  if (getBoosterRulesVersion() === sha) {
-    logger.info("found same boosterRules. Skip new download");
+  const currentBoosterRulesVersion = getBoosterRulesVersion();
+  if (currentBoosterRulesVersion === sha) {
+    logger.info(`Found same boosterRules version (${currentBoosterRulesVersion}). Skip new download`);
     return;
   }
-  logger.info("Downloading new boosterRules");
+  logger.info(`Found diverse boosterRules version (current: ${currentBoosterRulesVersion} new: ${sha})`);
   const resp = await axios.get(URL);
+  logger.info("Finished download of new boosterRules");
   const rules = resp.data.reduce((acc, { code, boosters, sheets }) => {
     const totalWeight = boosters.reduce((acc, { weight }) => acc + weight, 0);
 


### PR DESCRIPTION
## Linked tickets
- Fixes #1040

## Explanation of the issue
The booster rules version are always redownloaded because we save only the first 7 digits of the hash and check with the entire commit hash

## Description of your changes
I moved the PR intent (substring 7 first digits of the hash) to frontend. I also added some logs for completeness


## Screenshots


