### PR TITLE
fix colorless in colorbalanced sheets

### DIFF
--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -80,6 +80,7 @@ function getRandomCardsWithColorBalance({cardsByColor, cards}, numberOfCardsToPi
     "U": cardsByColor["U"].length * numberOfCardsToPick - n,
     "R": cardsByColor["R"].length * numberOfCardsToPick - n,
     "G": cardsByColor["G"].length * numberOfCardsToPick - n,
+    "c": cardsByColor["c"].length * numberOfCardsToPick - n,
   };
   const total = Object.values(nums).reduce((total, num) => total + num);
   while (ret.size < numberOfCardsToPick) {


### PR DESCRIPTION
## Linked tickets
- Fixes #1080 

## Explanation of the issue
We don't add colorless cards in balanced_color sheets. So we don't add lands and colorless cards (artifacts...)


## Description of your changes
I added the possibility to get also colorless cards in the function that choose a random card


## Screenshots


