### PR TITLE
add "build" to setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ It supports all their features, and many more.
 1) Install [Node.js](https://nodejs.org/en/download/) >= 12.0.0
 2) Run<br>
 `$ npm install`<br>
+`$ npm run build`<br>
 `$ npm start`
 3) Visit [http://localhost:1337](http://localhost:1337)
 


### PR DESCRIPTION
**Problem**
dr4ft.info was down, decided to stand up my own instance on digital ocean.
After running through setup there and starting the app I was getting 500 errors (not found).

**Solution**
You need to build a production release for there to be a `/built` static folder to serve!

---

Other thoughts:
1. should probably error if this folder doesn't exist
2. could add a `postinstall` script which runs this build...
3. docs need notes on production vs dev setup
4. we could schedule a git pull (of the latest tagged version on github) + npm run build??!
    - I checked and the static server doesn't seem to care about mutations in the `built/` folder
    - this is a terrible idea ... 