### PR TITLE
Add support for specifying particular card versions in a cube

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const _ = require("lodash");
 const path = require("path");
 const readFile = (path) => JSON.parse(fs.readFileSync(path, "UTF-8"));
-const { keyCardsUuidByName, keyCardsUuidByNumber, groupCardsBySet, groupCardsByName } = require("./import/keyCards");
+const { keyCardsUuidByNumber, groupCardsBySet, groupCardsByName } = require("./import/keyCards");
 
 const DATA_DIR = "data";
 const DRAFT_STATS_DIR = "draftStats";
@@ -110,7 +110,7 @@ const getCubableCardUuidByName = (cardName) => {
   if (card.number && byNumber[card.number]) return byNumber[card.number];
 
   return byNumber[Object.keys(byNumber).sort()[0]];
-}
+};
 
 const getCubableCardByName = (cardName) => {
   return getCardByUuid(getCubableCardUuidByName(cardName));

--- a/backend/data.js
+++ b/backend/data.js
@@ -87,7 +87,7 @@ const parseCubableCardName = (cardName) => {
   // * "Abrade" (just card name)
   // * "Abrade (CMR)" (card name + set code)
   // * "Abrade (CMR 410)" (card name + set code + number within set)
-  const match = cardName.match(/^(.*?)(?: +\(([^ ]+)(?: +(\d+))?\))? *$/);
+  const match = cardName.match(/^(.*?)(?: +\(([a-z0-9]+)(?: +([a-z0-9]+))?\))? *$/);
   if (!match) return null;
 
   return {name: match[1], set: match[2], number: match[3]};

--- a/backend/data.js
+++ b/backend/data.js
@@ -106,8 +106,8 @@ const getCubableCardUuidByName = (cardName) => {
   if (!card.set) return options.default;
 
   const byNumber = options[card.set];
-  if (!byNumber) return null;
-  if (card.number) return byNumber[card.number];
+  if (!byNumber) return options.default;
+  if (card.number && byNumber[card.number]) return byNumber[card.number];
 
   return byNumber[Object.keys(byNumber).sort()[0]];
 }

--- a/backend/data.js
+++ b/backend/data.js
@@ -87,7 +87,7 @@ const parseCubableCardName = (cardName) => {
   // * "Abrade" (just card name)
   // * "Abrade (CMR)" (card name + set code)
   // * "Abrade (CMR 410)" (card name + set code + number within set)
-  const match = cardName.match(/^(.*?)(?: +\(([a-z0-9]+)(?: +([a-z0-9]+))?\))? *$/);
+  const match = cardName.match(/^(.*?)(?: +\((\w+)(?: +(\w+))?\))? *$/);
   if (!match) return null;
 
   return {name: match[1], set: match[2], number: match[3]};

--- a/backend/import/keyCards.js
+++ b/backend/import/keyCards.js
@@ -17,12 +17,16 @@ const rarityPlucker = ({rarity}) => rarity;
 const numberPlucker = ({number}) => number;
 const uuidPlucker = ({uuid}) => uuid;
 const namePlucker = ({name}) => name.toLowerCase();
+const setPlucker = ({setCode}) => setCode.toLowerCase();
 
 const groupCardsUuidByRarity = (cards = []) =>
   groupCardsBy(rarityPlucker, uuidPlucker,cards);
 
 const groupCardsByName = (cards = []) =>
   groupCardsBy(namePlucker, card => card, cards);
+
+const groupCardsBySet = (cards = []) =>
+  groupCardsBy(setPlucker, card => card, cards);
 
 const keyCardsUuidByNumber = (cards = []) =>
   keyBy(numberPlucker, uuidPlucker, cards);
@@ -36,6 +40,7 @@ const keyCardsByUuid = (cards = []) =>
 module.exports = {
   groupCardsUuidByRarity,
   groupCardsByName,
+  groupCardsBySet,
   keyCardsUuidByNumber,
   keyCardsUuidByName,
   keyCardsByUuid


### PR DESCRIPTION
A cube card can now be written as "Abrade (CMR)" or "Abrade (CMR 659)" to specify the exact image that should be displayed. To enable this, the cubable card database has been expanded to include a map from card names to set codes to version numbers, as well as a "default" version for each card that's based on the same logic that's historically been used to select images.

If this approach looks good, I'd like to follow it up with an additional PR that loads card versions from CubeCobra, so that the versions drafted here match the versions specified in the cube list itself.

## Screenshots

Here's an image of a cube draft showing off different images for the same card:

![image](https://user-images.githubusercontent.com/188/100953118-bb91de00-34c6-11eb-8c73-7a55f04d6cc3.png)