### PR TITLE
actually use different versions in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
 
     strategy:
       matrix:
-        version:
-          - latest
-          - lts
+        node_version:
+          - 12
+          - 14
 
     runs-on: ubuntu-latest
 
@@ -31,8 +31,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v1
         with:
-          node-version: 12
-          check-latest: ${{matrix.version == 'latest'}}
+          node-version: ${{matrix.node_version}}
 
       - name: Install
         run: npm install


### PR DESCRIPTION
## Explanation of the issue
The current tests are run with the names lts and latest but are actually just run twice on version 12, the check-latest tag does nothing.


## Description of your changes
instead run them on version 12 and 14, travis used 15 which seems unavailable.
