### PR TITLE
fix game full

### DIFF
--- a/backend/game.js
+++ b/backend/game.js
@@ -189,6 +189,10 @@ module.exports = class Game extends Room {
       return sock.err("game already started");
     }
 
+    if (this.players.length >= this.seats) {
+      return sock.err("game is full");
+    }
+
     super.join(sock);
     this.logger.debug(`${sock.name} joined the game`);
 


### PR DESCRIPTION
## Linked tickets
- Fixes #1325

## Explanation of the issue
A player joining a game already full was still allowed to enter. 


## Description of your changes
There's a check at joining that throws an error to the joiner when the game is already full


## Screenshots


