### PR TITLE
Fix MTGJSON changelog link

### DIFF
--- a/frontend/src/lobby/Version.jsx
+++ b/frontend/src/lobby/Version.jsx
@@ -15,7 +15,7 @@ const Version = ({version, MTGJSONVersion, boosterRulesVersion}) => {
         {version}
       </a> (build {BUILD_DATE}) - Using <a href="https://www.mtgjson.com">MTGJSON</a> {" "}
       card data {" "}
-      <a href={`https://mtgjson.com/changelog/version-4/#_${MTGJSONVersion.version.replace(/\./g, "-")}`}>
+      <a href={`https://mtgjson.com/changelog/version-5/#_${MTGJSONVersion.version.replace(/\./g, "-")}`}>
         v{MTGJSONVersion.version}
       </a> ({MTGJSONVersion.date}) and <a href={"https://github.com/taw/magic-sealed-data"}>Magic Sealed Data</a> {" "}
         booster rules{" "}


### PR DESCRIPTION
## Linked tickets
- Related https://github.com/dr4fters/dr4ft/pull/1304

## Explanation of the issue
Link to MTGJSON changelog did not update with the switch to v5.


## Description of your changes
Use v5 URL.