### PR TITLE
add check on identifiers for basic lands

### DIFF
--- a/frontend/src/cardimage.js
+++ b/frontend/src/cardimage.js
@@ -53,7 +53,7 @@ export const getFallbackSrc = ({setCode, number}) => {
  * @returns {string} the image url to display
  */
 export const getCardSrc = ({identifiers, url, setCode, number, isBack}) => (
-  identifiers.scryfallId !== ""
+  identifiers && identifiers.scryfallId !== ""
     ? `${getScryfallImageWithLang(setCode, number)}${isBack ? "&face=back" : ""}`
     : url
 );

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -161,7 +161,7 @@ CardImage.propTypes = {
   loyalty:  PropTypes.string,
   setCode: PropTypes.string,
   number: PropTypes.string,
-  identifiers: PropTypes.array,
+  identifiers: PropTypes.object,
   mouseEntered: PropTypes.bool,
   url: PropTypes.string,
   flippedIsBack: PropTypes.bool,


### PR DESCRIPTION
## Linked tickets
- Fixes #1346

## Explanation of the issue
Basic lands do not have the mtgjson v5 field identifiers.


## Description of your changes
we add an additional check on identifiers to exist to render the image.


## Screenshots


