### PR TITLE
rename pick + burn vars as types of "selection"

### DIFF
--- a/backend/bot.js
+++ b/backend/bot.js
@@ -2,7 +2,7 @@ const {sample, pull, times} = require("lodash");
 const Player = require("./player");
 const logger = require("./logger");
 
-module.exports = class extends Player {
+module.exports = class Bot extends Player {
   constructor(picksPerPack, burnsPerPack, gameId) {
     super({
       isBot: true,

--- a/backend/player.js
+++ b/backend/player.js
@@ -20,7 +20,10 @@ class Player extends EventEmitter {
       isHost: false,
       time: 0,
       packs: [],
-      autopicks: [],
+      selected: {
+        picks: [],
+        burns: []
+      },
       pool: [],
       cap: {
         packs: {}

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -158,8 +158,8 @@ let App = {
         [id]: gameState
       });
     });
-    App.state.gameState.on("pickState", (state) => {
-      App.send("pickState", state);
+    App.state.gameState.on("setSelected", (state) => {
+      App.send("setSelected", state);
     });
   },
   error(err) {

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -19,11 +19,11 @@ const events = {
   },
   burn(card) {
     if (!App.state.gameState.isBurn(card.cardId)) {
-      App.state.gameState.addBurnCard(card.cardId, App.state.game.burnsPerPack);
-    } else if (App.state.gameState.isPickReady(App.state.picksPerPack, App.state.game.burnsPerPack)) {
+      App.state.gameState.updateCardBurn(card.cardId, App.state.game.burnsPerPack);
+    } else if (App.state.gameState.isSelectionReady(App.state.picksPerPack, App.state.game.burnsPerPack)) {
       App.state.gameState.resetPack();
       App.update();
-      App.send("pick");
+      App.send("confirmSelection");
     }
   },
   click(zoneName, card, e) {
@@ -377,12 +377,12 @@ const parseCubeOptions = () => {
 };
 
 const clickPack = (card) => {
-  if (!App.state.gameState.isAutopick(card.cardId)) {
-    App.state.gameState.updateAutopick(card.cardId, App.state.picksPerPack);
-  } else if (App.state.gameState.isPickReady(App.state.picksPerPack, App.state.game.burnsPerPack)) {
+  if (!App.state.gameState.isPick(card.cardId)) {
+    App.state.gameState.updateCardPick(card.cardId, App.state.picksPerPack);
+  } else if (App.state.gameState.isSelectionReady(App.state.picksPerPack, App.state.game.burnsPerPack)) {
     App.state.gameState.resetPack();
     App.update();
-    App.send("pick");
+    App.send("confirmSelection");
   }
 };
 

--- a/frontend/src/game/card/CardDefault.jsx
+++ b/frontend/src/game/card/CardDefault.jsx
@@ -10,7 +10,7 @@ import "./CardDefault.scss";
 export default class CardDefault extends Component {
   render () {
     const { card, zoneName } = this.props;
-    const isAutopickable = zoneName === ZONE_PACK && App.state.gameState.isAutopick(card.cardId);
+    const isAutopickable = zoneName === ZONE_PACK && App.state.gameState.isPick(card.cardId);
     const isAutoremovableAutopick = App.state.gameState.isAutoremovableAutopick(card.cardId, App.state.picksPerPack);
 
     return (

--- a/frontend/src/game/card/CardGlimpse.jsx
+++ b/frontend/src/game/card/CardGlimpse.jsx
@@ -28,7 +28,7 @@ class CardGlimpse extends Component {
   render () {
     const {zoneName, card} = this.props;
 
-    const isAutoPickable = zoneName === ZONE_PACK && App.state.gameState.isAutopick(card.cardId);
+    const isAutoPickable = zoneName === ZONE_PACK && App.state.gameState.isPick(card.cardId);
     const isBurn = App.state.gameState.isBurn(card.cardId);
 
     return (

--- a/frontend/src/game/card/CardGlimpse.scss
+++ b/frontend/src/game/card/CardGlimpse.scss
@@ -22,7 +22,7 @@
     transition: opacity 0.2s ease-in;
 
     display: grid;
-    grid-template-rows: calc(var(--height) * 0.6);
+    grid-template-rows: calc(var(--card-height) * 0.6);
     --col: calc(var(--card-width) / 2);
     grid-template-columns: var(--col) var(--col);
     grid-gap: var(--gap);


### PR DESCRIPTION
I've been reading this glimpse logic to see how I can support, and noticed that I was quite confused by the names.
This PR is a trial in aligning the language to be more consistent.

I know that renaming variables can be contentious, so if this does not serve or help, then I'm happy to change this around or close it.

| old language | new language |
|---|---|
| **autopicks** | selected.picks |
| **burns**     | selected.burns |
| isPickReady | isSelectionReady |
| pick      | confirmSelection |
| pickonTimeout | handleTimout |
| pickState (event) | setSelected |

In general:
- cards we're marking are "selected"
- we can select for "pick" (keep) or "burn" (destroy)
- autopick is more a concept about what happens on timeout which is a special case, so we remove the auto prefix most places