### PR TITLE
Errors in boosterGenerator.js 

### DIFF
--- a/scripts/download_booster_rules.js
+++ b/scripts/download_booster_rules.js
@@ -5,6 +5,15 @@ const {getBoosterRulesVersion, getCardByUuid, getSet, saveBoosterRules} = requir
 const URL = "https://raw.githubusercontent.com/taw/magic-sealed-data/master/sealed_basic_data.json";
 const REPO_URL = "https://api.github.com/repos/taw/magic-sealed-data/git/refs/heads/master";
 
+const CardsByColorInitial = () => ({
+  W: [],
+  B: [],
+  U: [],
+  R: [],
+  G: [],
+  c: []
+});
+
 async function fetch() {
   logger.info("Checking boosterRules repository");
   const repo = await axios.get(REPO_URL);
@@ -37,17 +46,17 @@ async function fetch() {
             try {
               const {uuid, colorIdentity, type} = getCard(cardCode);
               if (type === "Land" || colorIdentity.length === 0) {
-                (acc["c"] = acc["c"] || []).push(uuid);
+                acc["c"].push(uuid);
               } else {
                 colorIdentity.forEach((color) => {
-                  (acc[color] = acc[color] || []).push(uuid);
+                  acc[color].push(uuid);
                 });
               }
             } catch(err) {
               logger.warn(cardCode + " doesn't match any card");
             }
             return acc;
-          },{})
+          }, CardsByColorInitial())
         };
         return acc;
       }, {}),


### PR DESCRIPTION
in `backends/boosterGenerator.js` there's this section :

```js
  const nums = {
    "W": cardsByColor["W"].length * numberOfCardsToPick - n,
    "B": cardsByColor["B"].length * numberOfCardsToPick - n,
    "U": cardsByColor["U"].length * numberOfCardsToPick - n,
    "R": cardsByColor["R"].length * numberOfCardsToPick - n,
    "G": cardsByColor["G"].length * numberOfCardsToPick - n,
    "c": cardsByColor["c"].length * numberOfCardsToPick - n, // <<<< ERROR
  };
```

Not all sheets have colorless cards, so you get an Error `can't call length on undefined`.
This results in `makeBoosterFromRules` falling back to `getDefaultBooster` (boooo!)

Was tempted to fix this here but here by having that default to 0, but went upstream
and hit `download_booster_rules.js`

I don't fully know what the implications of this are but it means less error logging when that fallback happens which feels good .... and it doesn't seem like a sheet should be punished for not having any colorless cards. (FWIW there were only 12 or so that threw errors in the tests and the setCodes were not any that I recognised ... probably promos or something?)




- Fixes #xxxx