### PR TITLE
Fix bug decadent draft not spawning new packs

### DIFF
--- a/backend/player/human.js
+++ b/backend/player/human.js
@@ -131,6 +131,10 @@ module.exports = class Human extends Player {
     // Remove burned cards from pack
     remove(pack, (card) => this.selected.burns.includes(card.cardId));
 
+    // burn remaining if needed cards
+    const remainingToBurn = Math.min(pack.length, this.burnsPerPack - this.selected.burns.length);
+    pack.length-=remainingToBurn;
+
     const [next] = this.packs;
     if (!next)
       this.time = 0;
@@ -154,20 +158,11 @@ module.exports = class Human extends Player {
     pullAllWith(pack, this.selected.picks, (card, cardId) => card.cardId === cardId);
     pullAllWith(pack, this.selected.burns, (card, cardId) => card.cardId === cardId);
 
-
     // pick cards
     const remainingToPick = Math.min(pack.length, this.picksPerPack - this.selected.picks.length);
     times(remainingToPick, () => {
       const randomCard = sample(pack);
       this.selected.picks.push(randomCard.cardId);
-      pull(pack, randomCard);
-    });
-
-    // burn cards
-    const remainingToBurn = Math.min(pack.length, this.burnsPerPack - this.selected.burns.length);
-    times(remainingToBurn, () => {
-      const randomCard = sample(pack);
-      this.selected.burns.push(randomCard.cardId);
       pull(pack, randomCard);
     });
 


### PR DESCRIPTION
## Linked tickets
- Fixes #1391 

## Explanation of the issue
Since the work on Glimpse draft and the introduction of "burn" concept, we did not take care of burning cards from decadent draft.
In fact, as we chose to consider the decadent draft as X pick, burn the rest of cards, we forgot to burn them really when the pick selection was confirmed (because the player do not have to burn them manually, it's done by the backend).


## Description of your changes
Move the burn process at confirmSelection and not at handleTimeout because decadent draft do not select burn cards so we have to calculate them when the selection is confirmed.


## Screenshots


