### PR TITLE
fix bug of colorless card not showing

### DIFF
--- a/backend/boosterGenerator.js
+++ b/backend/boosterGenerator.js
@@ -80,7 +80,7 @@ function getRandomCardsWithColorBalance({cardsByColor, cards}, numberOfCardsToPi
     "U": cardsByColor["U"].length * numberOfCardsToPick - n,
     "R": cardsByColor["R"].length * numberOfCardsToPick - n,
     "G": cardsByColor["G"].length * numberOfCardsToPick - n,
-    "c": cardsByColor["c"].length * numberOfCardsToPick - n,
+    "c": cardsByColor["c"].length * numberOfCardsToPick,
   };
   const total = Object.values(nums).reduce((total, num) => total + num);
   while (ret.size < numberOfCardsToPick) {


### PR DESCRIPTION
## Linked tickets
- Fixes #1087

## Explanation of the issue
We had a problem, for a long time, about representation of colorless card in specific boosters.


## Description of your changes



## Screenshots


