### PR TITLE
Rearrange cubable cards with split name clashing

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -174,10 +174,10 @@ const writeCubeCards = (allSets, allCards) => {
     */
     .flatMap(([cardName, cardValues]) => {
       const names = cardName.split(" // ");
-      if (names.length <= 1) return [cardName, cardValues];
+      if (names.length <= 1) return [[cardName, cardValues]];
 
       return [
-        [cardName, cardValues], //
+        [cardName, cardValues],
         ...names.map((name) => [name, cardValues])
       ];
     })


### PR DESCRIPTION
## Linked tickets
- Fixes #1420

## Explanation of the issue
When we create the cards that can be cubable, split cards with name's clashing with other split cards create an issue. 
Fire // ice clashes with Start // Fire and in the end the content of the entry 'fire' depends on which card have been processed last.

## Description of your changes
We merge the cubable cards with care of clashing: the default value of the card name is calculated based on the priority (expansion > funny, etc). For example, Fire will have its default card being "fire // ice" is the old "fire // ice" and not Start // Fire


## Screenshots


