### PR TITLE
Hide "pick per pack" info for sealed

### DIFF
--- a/frontend/src/game/StartPanel.jsx
+++ b/frontend/src/game/StartPanel.jsx
@@ -14,7 +14,8 @@ const StartPanel = () => {
       <span>
         <div>Type: {gameType}</div>
         <div>Info: {App.state.game.packsInfo}</div>
-        <div>Picks per pack: {" " + App.state.picksPerPack }</div>
+        {!App.state.isSealed && 
+          <div>Picks per pack: {" " + App.state.picksPerPack }</div>}
         {(App.state.isHost && !App.state.didGameStart)
           ? <StartControls/>
           : <div />}


### PR DESCRIPTION
## Linked tickets
- Mentioned in https://github.com/dr4fters/dr4ft/issues/1444

## Explanation of the issue
The new "pick per pack" value was always displayed.


## Description of your changes
Display it only for draft games, not sealed.