### PR TITLE
Cleanup column keys after MWS removal

### DIFF
--- a/frontend/src/game/PlayersPanel.jsx
+++ b/frontend/src/game/PlayersPanel.jsx
@@ -127,7 +127,7 @@ const PlayerEntry = ({player, index}) => {
     //Move Player
     if(!didGameStart && length > 1)
       columns.push(
-        <td key={7}>
+        <td key={6}>
           <button onClick={()=> App.send("swap", [index, index - 1])}>
             <img src="../../media/arrow-up.png" width="16px"/>
           </button>
@@ -138,13 +138,13 @@ const PlayerEntry = ({player, index}) => {
     //Kick button
     if (index !== self && !isBot)
       columns.push(
-        <td key={8}>
+        <td key={7}>
           <button onClick={()=> App.send("kick", index)}>
             Kick
           </button>
         </td>);
     else
-      columns.push(<td key={9}/>);
+      columns.push(<td key={8}/>);
 
   }
 

--- a/frontend/src/game/PlayersPanel.jsx
+++ b/frontend/src/game/PlayersPanel.jsx
@@ -125,7 +125,7 @@ const PlayerEntry = ({player, index}) => {
 
   if (isHost) {
     //Move Player
-    if(!didGameStart && length > 1)
+    if (!didGameStart && length > 1)
       columns.push(
         <td key={6}>
           <button onClick={()=> App.send("swap", [index, index - 1])}>


### PR DESCRIPTION
## Linked tickets
- Related to #1442

## Explanation of the issue
With the removal of Magic Workstation, the MWS deck hash column got removed.
That way there was a gap in the key numbering.

## Description of your changes
Use consecutive numbering

