### PR TITLE
bugfix - random sets

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -251,12 +251,11 @@ const getPlayableSets = () => {
   return playableSets;
 };
 
+const SET_TYPES_EXCLUDED_FROM_RANDOM_SET = new Set(["custom", "random", "funny"]);
 const getRandomSet = () => {
   const allSets = getPlayableSets();
-  const allTypes = Object.keys(allSets);
-  delete allTypes["custom"];
-  delete allTypes["random"];
-  delete allTypes["funny"];
+  const allTypes = Object.keys(allSets)
+    .filter(setType => !SET_TYPES_EXCLUDED_FROM_RANDOM_SET.has(setType));
 
   const randomType = allTypes[allTypes.length * Math.random() << 0];
 

--- a/frontend/src/game/GameSettings.jsx
+++ b/frontend/src/game/GameSettings.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import App from "../app";
 import Checkbox from "../components/Checkbox";
-import './GameSettings.scss';
+import "./GameSettings.scss";
 
 const GameSettings = () => (
   <div className='GameSettings'>

--- a/frontend/src/utils.spec.js
+++ b/frontend/src/utils.spec.js
@@ -1,6 +1,6 @@
 const {describe, it} = require("mocha");
 const assert = require("assert");
-const {toTitleCase} = require("./../src/utils");
+const {toTitleCase} = require("./utils");
 
 describe("Acceptance tests for frontend utils", () => {
   it("toTitleCase() should capitalize each word", () => {


### PR DESCRIPTION
fixes: https://github.com/dr4fters/dr4ft/issues/1436

Pretty sure I got the bug :bug: 

**desicription** : found that while generating a "random set", that "random set" was one of the options that could be randomly selected... which causes later stuff to explode when it tries to build a booster from a set that is not a set, but a placeholder for a set

**fix** : make sure "random" is excluded from list of set types which can be selected from

NOTE: this fix also means that "custom" and "funny" types will be excluded from random selection (where it looks like they were not in the past, though the code was try to...)