### PR TITLE
Prettify text export

### DIFF
--- a/frontend/src/export/text.js
+++ b/frontend/src/export/text.js
@@ -9,7 +9,9 @@ export default {
 
 function text (name, deck) {
   return [
+    "Deck",
     ...deck[ZONE_MAIN].map(renderCopyCard),
+    "",
     "Sideboard",
     ...deck[ZONE_SIDEBOARD].map(renderCopyCard),
   ].join("\n");


### PR DESCRIPTION
## Explanation of the issue
The raw text export is not primary intended for machine consumption and not tweaked towards a particular import scheme used by any app - we have the other options for that.

The text export is probably used most by humans and should be as descriptive and informative as possible as it will probably be used to store in draft archives, writing articles or ask some friends for feedback...

## Description of your changes

- Add deck headline
- Add line break before sideboard starts

All for the looks ✨ 
