### PR TITLE
Remove lint from npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nodemon": "nodemon ./app.js -e html,js --ignore built --ignore frontend",
     "nodemon:debug": "nodemon --inspect-brk=1338 ./app.js -e html,js --ignore built --ignore frontend",
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "npm run postinstall && npm run test:js && npm run lint",
+    "test": "npm run postinstall && npm run test:js",
     "test:js": "mocha \"./{,!(node_modules|built)/**/}*.spec.*js\" --exit --require @babel/register",
     "postinstall": " npm run download_allsets && npm run download_booster_rules && webpack --config webpack.prod.js",
     "update_database": "node scripts/update_database ",


### PR DESCRIPTION
## Explanation of the issue

If there is a linting error, 3 CI builds will currently fail.
The `test 12`, `test 14` and our dedicated `eslint` one [which only runs lint](https://github.com/dr4fters/dr4ft/blob/master/.github/workflows/tests.yml#L87). As the test builds might otherwise succeed, one need to manually double check them to be sure what's the issue every time.

I guess we can safely remove it from the tests to improve their expressiveness. Once a PR is created, the linting is still checked super quickly and shown separately... and one can easily run `npm run lint` locally still.

## Description of your changes
- Remove lint from npm test
