### PR TITLE
Prettify Cockatrice export

### DIFF
--- a/frontend/src/export/cockatrice.js
+++ b/frontend/src/export/cockatrice.js
@@ -28,6 +28,7 @@ ${
   copy(name, deck) {
     return [
       ...deck[ZONE_MAIN].map(renderCopyCard),
+      "",
       "Sideboard",
       ...deck[ZONE_SIDEBOARD].map(renderCopyCard),
     ].join("\n");

--- a/frontend/src/export/cockatrice.spec.js
+++ b/frontend/src/export/cockatrice.spec.js
@@ -50,6 +50,7 @@ const copyOutput = () => (
 1 Riverglide Pathway
 1 Graf Rats
 1 Dead // Gone
+
 Sideboard
 1 Catch // Release
 1 Who // What // When // Where // Why`


### PR DESCRIPTION
## Linked tickets
- Related #1462

## Description of your changes
When importing decks to Cockatrice via the clipboard, you only see a long single list with no visual breaks.
Now, that there is an empty line between the actual deck and sideboard it's easier navigate in the list and review the import before confirming.

I tested this with some lists and Cockatrice does not care about empty lines.

Fun fact: I realized this way that cards in the `Junk` zone are not exported at all! 🙈 👍 