### PR TITLE
Fix custom card images not displaying + allow text in column view card preview

### DIFF
--- a/frontend/src/cardimage.js
+++ b/frontend/src/cardimage.js
@@ -40,12 +40,7 @@ export const getFallbackSrc = ({setCode, number}) => {
     return null;
   }
 
-  const url = getScryfallImage(setCode, number);
-  return ev => {
-    if (url !== ev.target.src) {
-      ev.target.src = url;
-    }
-  };
+  return getScryfallImage(setCode, number);
 };
 /**
  * @description builds an image url based on the card properties

--- a/frontend/src/cardimage.js
+++ b/frontend/src/cardimage.js
@@ -53,7 +53,7 @@ export const getFallbackSrc = ({setCode, number}) => {
  * @returns {string} the image url to display
  */
 export const getCardSrc = ({identifiers, url, setCode, number, isBack}) => (
-  identifiers && identifiers.scryfallId !== ""
+  identifiers && identifiers.scryfallId != null && identifiers.scryfallId !== ""
     ? `${getScryfallImageWithLang(setCode, number)}${isBack ? "&face=back" : ""}`
     : url
 );

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -4,14 +4,13 @@ import PropTypes from "prop-types";
 import App from "../app";
 import {getZoneDisplayName} from "../zones";
 import Spaced from "../components/Spaced";
-import {getCardSrc, getFallbackSrc} from "../cardimage";
 import CardBase from "./card/CardBase.jsx"
 import "./Cols.scss"
 
 class Cols extends Component {
   constructor(props) {
     super(props);
-    this.state={
+    this.state = {
       className: "right",
       card: undefined
     };
@@ -42,6 +41,7 @@ class Cols extends Component {
 
     this.setState({ card, className });
   }
+  
   onMouseLeave() {
     this.setState({
       card: undefined
@@ -52,7 +52,7 @@ class Cols extends Component {
     return (
       <div className="Cols">
         <Zones onMouseOver={this.onMouseEnter} zoneNames={this.props.zones} onMouseLeave={this.onMouseLeave} />
-        <ImageHelper onMouseEnter={this.onMouseEnter} {...this.state} />
+        <CornerCardPreview {...this.state} />
       </div>
     );
   }
@@ -72,7 +72,7 @@ const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
       let items = zone[key].map((card, index) =>
         <div 
           className="card-container"
-          key={index}
+          key={card.uuid || card.name}
           onClick={App._emit("click", zoneName, card)}
           onMouseOver={e => onMouseOver(card, e)}
           onMouseLeave={onMouseLeave} >
@@ -105,20 +105,19 @@ const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
   return zoneNames.map(renderZone);
 };
 
-const ImageHelper = ({className, card}) => {
+const CornerCardPreview = ({className, card}) => {
   // This is the on-hover enlarged helper you see in the bottom left when hovering over a card in column view
   if (!card) return <div />
 
   return (
-      <div className={`helper ${className}`}>
+      <div className={`CornerCardPreview ${className}`}>
+        {card.isDoubleFaced && <div className="card"><CardBase card={card} reversed /></div>}
         <div className="card"><CardBase card={card} /></div>
-        {card.isDoubleFaced && <div className={`card ${card.layout === "flip" ? "flipped" : ""}`}><CardBase card={card} /></div>}
       </div>
   )
 };
 
-ImageHelper.propTypes = {
-  onMouseEnter: PropTypes.func.isRequired,
+CornerCardPreview.propTypes = {
   className: PropTypes.string.isRequired,
   card: PropTypes.object
 };

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -72,7 +72,7 @@ const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
       let items = zone[key].map((card, index) =>
         <div 
           className="card-container"
-          key={card.uuid || card.name}
+          key={`${index}-${card.uuid || card.name}`}
           onClick={App._emit("click", zoneName, card)}
           onMouseOver={e => onMouseOver(card, e)}
           onMouseLeave={onMouseLeave} >

--- a/frontend/src/game/Cols.jsx
+++ b/frontend/src/game/Cols.jsx
@@ -105,27 +105,14 @@ const Zones = ({onMouseOver, zoneNames, onMouseLeave}) => {
   return zoneNames.map(renderZone);
 };
 
-const ImageHelper = ({onMouseEnter, className, card}) => {
+const ImageHelper = ({className, card}) => {
   // This is the on-hover enlarged helper you see in the bottom left when hovering over a card in column view
   if (!card) return <div />
 
-  // TODO - consider text case
   return (
-    card.isDoubleFaced
-      ? <div className={className} id="doubleimg">
-        <img className="card" src={getCardSrc(card)} onError= {getFallbackSrc(card)} onMouseEnter={onMouseEnter.bind(card)} />
-        <img className={`card ${card.layout === "flip" ? "flipped" : ""}`}
-          src={getCardSrc({ ...card, isBack: card.flippedIsBack, number: card.flippedNumber, })}
-          onError={e => e.target.src = card.flippedCardURL}
-          onMouseEnter={onMouseEnter.bind(card)} />
-      </div>
-
-      : <div id='img' className = {className}>
-        <img
-          className = "image-inner"
-          onMouseEnter = {e => onMouseEnter(card, e)}
-          onError= {getFallbackSrc(card)}
-          src = {getCardSrc(card)} />
+      <div className={`helper ${className}`}>
+        <div className="card"><CardBase card={card} /></div>
+        {card.isDoubleFaced && <div className={`card ${card.layout === "flip" ? "flipped" : ""}`}><CardBase card={card} /></div>}
       </div>
   )
 };

--- a/frontend/src/game/Cols.scss
+++ b/frontend/src/game/Cols.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  .helper {
+  .CornerCardPreview {
     position: fixed;
     bottom: 0;
     z-index: 101;
@@ -38,9 +38,11 @@
     }
 
     .card {
-      width: var(--card-width);
-      height: var(--card-height);
+      display: inline-flex;
+      position: relative;
+      margin: 0;
       cursor: pointer;
+      padding: 1px;
     }
   }
 }

--- a/frontend/src/game/Cols.scss
+++ b/frontend/src/game/Cols.scss
@@ -20,4 +20,27 @@
       }
     }
   }
+
+  .helper {
+    position: fixed;
+    bottom: 0;
+    z-index: 101;
+
+    --card-width: 240px;
+    --card-height: 340px;
+
+    &.left {
+      left: 0;
+    }
+
+    &.right {
+      right: 0;
+    }
+
+    .card {
+      width: var(--card-width);
+      height: var(--card-height);
+      cursor: pointer;
+    }
+  }
 }

--- a/frontend/src/game/card/CardBase.jsx
+++ b/frontend/src/game/card/CardBase.jsx
@@ -14,7 +14,10 @@ export default class CardBase extends Component {
       mouseEntered: false,
       isFlipped: false,
       url: getCardSrc(this.props.card),
+      imageErrored: false
     };
+
+    this.onImageError = this.onImageError.bind(this);
 
     if (this.props.card.isDoubleFaced) {
       this.onMouseEnter = this.onMouseEnter.bind(this);
@@ -29,7 +32,7 @@ export default class CardBase extends Component {
       url: getCardSrc({
         ...this.props.card,
         isBack: this.props.card.flippedIsBack,
-        number: this.props.card.flippedNumber,
+        number: this.props.card.flippedNumber || this.props.card.number,
       })
     });
   }
@@ -42,6 +45,10 @@ export default class CardBase extends Component {
     });
   }
 
+  onImageError () {
+    this.setState({ imageErrored: true });
+  }
+
   render () {
     const { card } = this.props;
     // at the moment for Text view, you can't see both sides of a card on hover
@@ -51,8 +58,8 @@ export default class CardBase extends Component {
       <div className={`CardBase ${card.foil ? "-foil " : ""}`}>
         <CardBaseText {...card}/>
         {
-          App.state.cardSize !== "text" &&
-            <CardBaseImage mouseEntered={this.state.mouseEntered} imgUrl={this.state.url} {...card}/>
+          App.state.cardSize !== "text" && !this.state.imageErrored &&
+            <CardBaseImage mouseEntered={this.state.mouseEntered} imgUrl={this.state.url} onError={this.onImageError} {...card}/>
         }
 
         {this.props.children}
@@ -67,8 +74,8 @@ export default class CardBase extends Component {
       >
         <CardBaseText {...card} />
         {
-          App.state.cardSize !== "text" &&
-            <CardBaseImage mouseEntered={this.state.mouseEntered} imgUrl={this.state.url} {...card}/>
+          App.state.cardSize !== "text" && !this.state.imageErrored &&
+            <CardBaseImage mouseEntered={this.state.mouseEntered} imgUrl={this.state.url} onError={this.onImageError} {...card}/>
         }
         {this.props.children}
       </div>
@@ -80,16 +87,12 @@ CardBase.propTypes = {
   card: PropTypes.object.isRequired,
 };
 
-const CardBaseImage = ({ mouseEntered, url, foil, flippedIsBack, flippedNumber, identifiers, name, setCode = "", number = "" }) => (
+const CardBaseImage = ({ mouseEntered, imgUrl, onError, foil, flippedIsBack, flippedNumber, identifiers, name, setCode = "", number = "" }) => (
   <div className="CardBaseImage">
     <img
       title={name}
-      onError={getFallbackSrc({ setCode, number })}
-      src={
-        !mouseEntered
-          ? getCardSrc({ identifiers, setCode, url, number })
-          : getCardSrc({ identifiers, setCode, url, number: flippedNumber, isBack: flippedIsBack })
-      }
+      onError={onError}
+      src={imgUrl}
     />
   </div>
 );
@@ -110,7 +113,8 @@ CardBaseImage.propTypes = {
   mouseEntered: PropTypes.bool,
   url: PropTypes.string,
   flippedIsBack: PropTypes.bool,
-  flippedNumber: PropTypes.string
+  flippedNumber: PropTypes.string,
+  onError: PropTypes.func
 };
 
 const CardBaseText = ({ name, manaCost, type = "", rarity = "", power = "", toughness = "", text = "", loyalty= "" }) => (

--- a/frontend/src/game/card/CardBase.jsx
+++ b/frontend/src/game/card/CardBase.jsx
@@ -87,7 +87,7 @@ CardBase.propTypes = {
   card: PropTypes.object.isRequired,
 };
 
-const CardBaseImage = ({ mouseEntered, imgUrl, onError, foil, flippedIsBack, flippedNumber, identifiers, name, setCode = "", number = "" }) => (
+const CardBaseImage = ({ imgUrl, onError, name }) => (
   <div className="CardBaseImage">
     <img
       title={name}
@@ -110,7 +110,6 @@ CardBaseImage.propTypes = {
   setCode: PropTypes.string,
   number: PropTypes.string,
   identifiers: PropTypes.object,
-  mouseEntered: PropTypes.bool,
   url: PropTypes.string,
   flippedIsBack: PropTypes.bool,
   flippedNumber: PropTypes.string,

--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -36,9 +36,6 @@
 }
 
 .CardBaseText {
-  z-index: -1;
-  // z-index needed otherwise CardBaseText overflow text appears on top of image in Chrome!
-
   width: calc(var(--card-width) - 10px);
   height: calc(var(--card-height) - 10px);
   // 10px = 2* (padding + border)
@@ -84,6 +81,9 @@
   }
 
   .body {
+    z-index: -1;
+    // z-index needed otherwise CardBaseText overflow text appears on top of image in Chrome!
+
     font-size: 0.9rem;
     line-height: 1.2rem;
 

--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -36,6 +36,9 @@
 }
 
 .CardBaseText {
+  z-index: -1;
+  // z-index needed otherwise CardBaseText overflow text appears on top of image in Chrome!
+
   width: calc(var(--card-width) - 10px);
   height: calc(var(--card-height) - 10px);
   // 10px = 2* (padding + border)
@@ -81,9 +84,6 @@
   }
 
   .body {
-    z-index: -1;
-    // z-index needed otherwise CardBaseText overflow text appears on top of image in Chrome!
-
     font-size: 0.9rem;
     line-height: 1.2rem;
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -368,21 +368,6 @@ input[type="checkbox"], input[type="radio"] {
   font-style: italic;
 }
 
-/** Card styles **/
-
-.card {
-  display: inline-flex;
-  position: relative;
-  margin: 0;
-  cursor: pointer;
-  padding: 1px;
-}
-
-.image-inner {
-  width: inherit;
-}
-
-
 /** Misc **/
 
 .name {
@@ -453,14 +438,6 @@ input[type="checkbox"], input[type="radio"] {
 
 .icon-bot {
   background-color: rgba(0, 0, 0, 0.25);
-}
-
-.flipped {
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
 }
 
 #players th,

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -364,13 +364,6 @@ input[type="checkbox"], input[type="radio"] {
 
 /** Zones **/
 
-#img,
-.card {
-  height: 340px;
-  width: 240px;
-  cursor: pointer;
-}
-
 .waiting {
   font-style: italic;
 }
@@ -462,22 +455,6 @@ input[type="checkbox"], input[type="radio"] {
   background-color: rgba(0, 0, 0, 0.25);
 }
 
-#img,
-#doubleimg {
-  position: fixed;
-  bottom: 0;
-  z-index: 101;
-}
-
-#img.left,
-#doubleimg.left {
-  left: 0;
-}
-
-#img.right,
-#doubleimg.right {
-  right: 0;
-}
 .flipped {
   -webkit-transform: rotate(180deg);
   -moz-transform: rotate(180deg);


### PR DESCRIPTION
**Fixes #1335:**
	- Adds a check to make sure the scryfall id exists before checking to see if it's an empty string.

**Hide missing image icon:**
	- If a card image has an error loading it will be marked as errored and not draw the image so the missing image icon and alt text are hidden.
![hEyQ6RE](https://user-images.githubusercontent.com/2178008/108926560-8bac3e00-76a3-11eb-97cb-36ccd2e35ccb.png)

**Allow text in column view preview:**
	- Moves the `ImageHelper` from the column view to use `CardBase` instead of just drawing the images. This allows for text cards to have a preview and also for any card display changes to stay consistent across the site.
![O8vcREf](https://user-images.githubusercontent.com/2178008/108926940-40465f80-76a4-11eb-9324-fd66e419f686.png)

