### PR TITLE
More exclusions from random sets

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -251,7 +251,7 @@ const getPlayableSets = () => {
   return playableSets;
 };
 
-const SET_TYPES_EXCLUDED_FROM_RANDOM_SET = new Set(["custom", "random", "funny"]);
+const SET_TYPES_EXCLUDED_FROM_RANDOM_SET = new Set(["custom", "funny", "draft_innovation", "starter", "random"]);
 const getRandomSet = () => {
   const allSets = getPlayableSets();
   const allTypes = Object.keys(allSets)


### PR DESCRIPTION
## Linked tickets
- Fixes #1472

## Explanation of the issue
Non-default sets, which are not designed for normal drafting like "Battlebond" used to be part of the random set selection.

## Description of your changes
Exclude `Draft_Innovation` and `Starter` set types from `Random Set`.