### PR TITLE
Fixes card issue from #1470

### DIFF
--- a/frontend/src/game/card/CardBase.jsx
+++ b/frontend/src/game/card/CardBase.jsx
@@ -23,7 +23,7 @@ export default class CardBase extends Component {
 
     this.state = {
       url: this.getCardImage(DEFAULT),
-      isFlipped: false, // this is relative to this.props.showFlipped
+      isFlipped: this.props.showFlipped, // this is relative to this.props.showFlipped
       imageErrored: false
     };
   }


### PR DESCRIPTION
**Fixes small issue in #1470**
Fixes the issue I found in @mixmix's changes to my card change pr where in the column view hover preview cards weren't being flipped correctly by setting the initial value of `isFlipped` to the value of the `showFlipped` prop.

Before: 
![chrome_YRXwlrDYr7](https://user-images.githubusercontent.com/2178008/110625437-4be96880-8204-11eb-8a7a-8dea1af414f9.jpg)

After:
![5CMq8vW](https://user-images.githubusercontent.com/2178008/110630141-dda7a480-8209-11eb-94d3-bfed3abfe2fd.jpg)
