### PR TITLE
round card corners

### DIFF
--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -56,7 +56,7 @@
   font-size: 16px;
   padding: 4px;
   border: 1px solid #555;
-  border-radius: 6px;
+  border-radius: 8px;
 
   display: grid;
   grid-template-rows: auto auto 1fr;
@@ -122,5 +122,6 @@
     height: var(--card-height);
     max-width: var(--card-width);
     max-height: var(--card-height);
+    border-radius: 8px;
   }
 }


### PR DESCRIPTION
some of the pre-release set cards have square edges ... most of the card images are rounded ....it hurt so I've fixed it


# before :rotating_light: 
![Screenshot_2021-03-11 dr4ft info(1)](https://user-images.githubusercontent.com/2665886/110761382-8c082400-82b4-11eb-9a72-91721438c523.png)

---

# after :cactus: 
![Screenshot_2021-03-11 Screenshot](https://user-images.githubusercontent.com/2665886/110761369-890d3380-82b4-11eb-8e1d-cb226ed626a0.png)


