### PR TITLE
add placeholder cards while waiting for packs

### DIFF
--- a/backend/game.js
+++ b/backend/game.js
@@ -17,7 +17,15 @@ module.exports = class Game extends Room {
     super({ isPrivate });
     const gameID = uuid.v1();
     Object.assign(this, {
-      title, seats, type, isPrivate, modernOnly, totalChaos, cube, chaosPacksNumber, picksPerPack,
+      title,
+      seats: parseInt(seats),
+      type,
+      cube,
+      isPrivate,
+      modernOnly,
+      totalChaos,
+      chaosPacksNumber,
+      picksPerPack: parseInt(picksPerPack),
       delta: -1,
       hostID: hostId,
       id: gameID,

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -49,6 +49,7 @@ const Zone = ({ name: zoneName }) => {
   const remainingCardsToSelect = Math.min(picksPerPack, cards.length);
   const remainingCardsToBurn = Math.min(game.burnsPerPack, cards.length);
   const canConfirm = gameState.isSelectionReady(remainingCardsToSelect, remainingCardsToBurn)
+  const cardsInNextPack = packSize - (pickNumber * (picksPerPack + game.burnsPerPack)) % packSize
 
   return (
     <div className='Grid zone'>
@@ -98,7 +99,7 @@ const Zone = ({ name: zoneName }) => {
           cards.length === 0 && isPackZone && // TODO game is not over!
           ([
             <h2 className='waiting' key='other'>Waiting for the next pack...</h2>,
-            Array(packSize - pickNumber % packSize).fill(0)
+            Array(cardsInNextPack).fill(0)
               .map((_, i) => <CardPlaceholder key={i} />)
           ])
         }

--- a/frontend/src/game/Grid.scss
+++ b/frontend/src/game/Grid.scss
@@ -2,6 +2,8 @@
   --card-width: 240px;
   --card-height: 334.2px;
 
+  margin-bottom: 20px;
+
   > .header {
     display: grid;
     grid-template-columns: auto auto auto;
@@ -56,7 +58,17 @@
     grid-template-rows: repeat(auto-fill, var(--card-height));
     grid-template-columns: repeat(auto-fill, var(--card-width));
     grid-gap: 2px;
-  }
 
-  h2 {}
+    position: relative;
+
+    .waiting {
+      position: absolute;
+      top: 0;
+      left: 22px;
+
+      color: white;
+      padding: 0 5px;
+      background: #a8a4a4;
+    }
+  }
 }

--- a/frontend/src/game/card/CardPlaceholder.jsx
+++ b/frontend/src/game/card/CardPlaceholder.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import './CardPlaceholder.scss';
+
+export default () => (
+  <div className='CardPlaceholder'>
+  </div>
+)

--- a/frontend/src/game/card/CardPlaceholder.scss
+++ b/frontend/src/game/card/CardPlaceholder.scss
@@ -1,0 +1,9 @@
+.CardPlaceholder {
+  --border-width: 1px;
+
+  width: calc(var(--card-width) - 2 * var(--border-width));
+  height: calc(var(--card-height) - 2 * var(--border-width));
+
+  border: var(--border-width) solid #b0afaf;
+  border-radius: 10px;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2665886/111371816-c3386400-86fe-11eb-9656-2d088e74b884.png)

This is a minor tweak which puts placehoder cards in to show the expected number of cards you will receive when the next pack arrives. It stops the UI jumping around so much when a pack arrives and is visually satisfying as the cards "step in" to the shadows that are there already