### PR TITLE
CI: Add node.js 15 to the mix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 12
-          - 14
+          - 12.x
+          - 14.x
+          - 15.x
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Explanation of the issue
Node 12 entered maintainance LTS.
Node 14 is the new active LTS version.
Therefore we do no longer test against the current release.

See the Long Term Support (LTS) schedule page: https://nodejs.org/en/about/releases/

## Description of your changes
- Add Node 15
- Use [suggested version style from docs](https://docs.github.com/en/actions/guides/building-and-testing-nodejs#specifying-the-nodejs-version)