### PR TITLE
Dockerfile: Use Node LTS-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.19.0-alpine
+FROM node:lts-alpine
 ENV NPM_CONFIG_LOGLEVEL warn
 
 # Install "git"


### PR DESCRIPTION
## Explanation of the issue

> (https://github.com/dr4fters/dr4ft/pull/1503#issuecomment-806360781)
>Bad bot. LTS versions of node only

Here you go, @mixmix.

## Description of your changes
- Use the current active LTS image of Node (same "alpine" base as before)

We have to see if dependabot knows about the LTS tag or still tries to update to 16 once available. Then, we can still exclude the Dockerfile from dependabot updates.