### PR TITLE
Fix can get data directory test for Windows

### DIFF
--- a/backend/data.spec.js
+++ b/backend/data.spec.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const path = require("path");
 const data = require("./data");
-const {describe, it} = require("mocha");
+const { describe, it } = require("mocha");
 
 describe("Acceptance tests for Data functions", () => {
   describe("can find certain starter sets", () => {
@@ -18,7 +18,7 @@ describe("Acceptance tests for Data functions", () => {
 
       assert(dataDir);
       assert(path.isAbsolute(dataDir));
-      assert.equal(dataDir, `${repoRoot}/data`);
+      assert.strictEqual(dataDir, path.join(repoRoot, "data"));
     });
   });
 });


### PR DESCRIPTION
One of the unit tests was assuming a forward slash seperator,
even though the implementation uses path.join(). This meant the
test would fail on Windows platforms because on Windows path.join()
would use a back slash path seperator.

Type: Bug Fix