### PR TITLE
recently loaded card-images ease in

### DIFF
--- a/frontend/src/game/card/CardBase.jsx
+++ b/frontend/src/game/card/CardBase.jsx
@@ -113,7 +113,11 @@ const CardBaseImage = ({ src, handleError, name }) => (
   <div className="CardBaseImage">
     <img
       title={name}
+      className='loading'
+
       onError={handleError}
+      onLoad={ev => ev.target.classList.remove("loading")}
+  
       src={src}
     />
   </div>

--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -6,6 +6,15 @@
     grid-row: 1;
     grid-column: 1;
     transition: transform 0.2s ease-in;
+
+    img {
+      transition: all 0.2s;
+
+      &.loading {
+        opacity: 0;
+        transform: scale(0.95);
+      }
+    }
   }
 
   &.-flipped {


### PR DESCRIPTION
**BEFORE**
![Peek 2021-10-13 23-33](https://user-images.githubusercontent.com/2665886/137116995-6f4d2282-1828-40af-8d5b-1bff72a58421.gif)
_*Please ignore the previews of enlarged images you see for a moment - that's an image enlarging extension I have_



## Explanation of the issue

cards with images loading arrive abruptly

## Description of your changes

this pull request has card images arrive by fading in (quickly). The experience is smoother, and slightly more pleasant


**AFTER**
![Peek 2021-10-14 00-03](https://user-images.githubusercontent.com/2665886/137121169-93f812e3-275f-46d9-8c08-45931588c83a.gif)
