### PR TITLE
Significantly improve custom set upload UX

### DIFF
--- a/backend/import/xml/parser.js
+++ b/backend/import/xml/parser.js
@@ -50,6 +50,9 @@ function parse(content) {
 
   cards.card.forEach(c => {
     const { text: setCode, num = 0, picurl = "", picURL = "", rarity } = c.set;
+    if (c.token) {
+      return;
+    }
     if (!/common|basic|uncommon|rare|mythic/i.test(rarity)) {
       throw new Error(`<card> property <set> of "${c.name}" must contain an attribute rarity with one of common, basic, uncommon, rare or mythic`);
     }

--- a/backend/import/xml/parser.js
+++ b/backend/import/xml/parser.js
@@ -1,32 +1,32 @@
 const parser = require("fast-xml-parser");
 
 function parse(content) {
-  const parsedContent = parser.parse(content, {ignoreAttributes: false, attributeNamePrefix: "", textNodeName: "text"});
+  const parsedContent = parser.parse(content, { ignoreAttributes: false, attributeNamePrefix: "", textNodeName: "text" });
   const root = parsedContent.cockatrice_carddatabase;
   if (!root) {
-    throw new Error("root node <cockatrice_carddatabase> must be present");
+    throw new Error("XML root node <cockatrice_carddatabase> must be present");
   }
 
-  const {sets, cards} = root;
+  const { sets, cards } = root;
   if (!cards) {
-    throw new Error("node <cards> must be present");
+    throw new Error("XML node <cards> must be present");
   }
 
   const jsonSets = {};
 
   if (sets) {
     if (!sets.set) {
-      throw new Error("node <sets> must be made of <set>");
+      throw new Error("XML node <sets> must be made of <set>");
     }
 
     if (typeof sets.set === "object" && !Array.isArray(sets.set)) {
       sets.set = [sets.set];
     }
 
-    sets.set.forEach((set) => {
+    sets.set.forEach((set, set_index) => {
       const { name: code, longname: name = "", settype: type = "", releasedate: releaseDate = "" } = set;
       if (!code) {
-        throw new Error("<sets> property <set> must contain an attribute name");
+        throw new Error(`<sets> property <set> of set number ${set_index} must contain an attribute "name"`);
       }
       jsonSets[code] = {
         code,
@@ -51,10 +51,10 @@ function parse(content) {
   cards.card.forEach(c => {
     const { text: setCode, num = 0, picurl = "", picURL = "", rarity } = c.set;
     if (!/common|basic|uncommon|rare|mythic/i.test(rarity)) {
-      throw new Error("<card> property <set> must contain an attribute rarity with one of common, basic, uncommon, rare or mythic");
+      throw new Error(`<card> property <set> of "${c.name}" must contain an attribute rarity with one of common, basic, uncommon, rare or mythic`);
     }
     if (!setCode) {
-      throw new Error("<card> property <set> must contain a value");
+      throw new Error(`<card> property <set> of "${c.name}" must contain a value`);
     }
     if (!jsonSets[setCode]) {
       jsonSets[setCode] = {
@@ -96,7 +96,7 @@ function parse(content) {
       url: picurl || picURL,
       layout,
       number: parseInt(num),
-      supertypes : [],
+      supertypes: [],
       side,
       isAlternative: false,
       colors: fixedColors

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -1,10 +1,10 @@
 import _ from "utils/utils";
-import {vanillaToast} from "vanilla-toast";
+import { vanillaToast } from "vanilla-toast";
 import DOMPurify from "dompurify";
-import {range, times, constant} from "lodash";
+import { range, times, constant } from "lodash";
 
 import App from "./app";
-import {ZONE_JUNK, ZONE_MAIN, ZONE_PACK, ZONE_SIDEBOARD} from "./zones";
+import { ZONE_JUNK, ZONE_MAIN, ZONE_PACK, ZONE_SIDEBOARD } from "./zones";
 import exportDeck from "./export";
 
 /**
@@ -28,7 +28,7 @@ const events = {
       App.send("confirmSelection");
     }
   },
-  confirmSelection () {
+  confirmSelection() {
     if (App.state.gameState.isSelectionReady(App.state.picksPerPack, App.state.game.burnsPerPack)) {
       App.send("confirmSelection");
     }
@@ -48,7 +48,7 @@ const events = {
     App.update();
   },
   copy() {
-    const {exportDeckFormat: format, exportDeckFilename: filename} = App.state;
+    const { exportDeckFormat: format, exportDeckFilename: filename } = App.state;
     const textField = document.createElement("textarea");
     textField.value = exportDeck[format].copy(filename, collectDeck());
 
@@ -60,7 +60,7 @@ const events = {
     hash();
   },
   download() {
-    const {exportDeckFormat: format, exportDeckFilename: filename} = App.state;
+    const { exportDeckFormat: format, exportDeckFilename: filename } = App.state;
     const data = exportDeck[format].download(filename, collectDeck());
 
     _.download(data, filename + exportDeck[format].downloadExtension);
@@ -68,8 +68,8 @@ const events = {
     hash();
   },
   start() {
-    const {addBots, useTimer, timerLength, shufflePlayers} = App.state;
-    const options = {addBots, useTimer, timerLength, shufflePlayers};
+    const { addBots, useTimer, timerLength, shufflePlayers } = App.state;
+    const options = { addBots, useTimer, timerLength, shufflePlayers };
     App.send("start", options);
   },
   pickNumber(pick) {
@@ -98,7 +98,7 @@ const events = {
     App.save("log", draftLog);
   },
   getLog() {
-    const {gameId, log, players, self, sets, gamesubtype, exportDeckFilename} = App.state;
+    const { gameId, log, players, self, sets, gamesubtype, exportDeckFilename } = App.state;
     const isCube = /cube/.test(gamesubtype);
     const date = new Date().toISOString().slice(0, -5).replace(/-/g, "").replace(/:/g, "").replace("T", "_");
     const data = [
@@ -123,30 +123,33 @@ const events = {
   },
 
   create() {
-    let {gametype, gamesubtype, seats, title, isPrivate, modernOnly, totalChaos, chaosDraftPacksNumber, chaosSealedPacksNumber, picksPerPack} = App.state;
+    console.log("BEEP BOOP", JSON.stringify(App.state, undefined, 2));
+    let { gametype, gamesubtype, seats, title, isPrivate, modernOnly, totalChaos, chaosDraftPacksNumber, chaosSealedPacksNumber, picksPerPack } = App.state;
     seats = Number(seats);
 
     //TODO: either accept to use the legacy types (draft, sealed, chaos draft ...) by  keeping it like this
     // OR change backend to accept "regular draft" instead of "draft" and "regular sealed" instead of "sealed"
     const type = `${/regular/.test(gamesubtype) ? "" : gamesubtype + " "}${gametype}`;
 
-    let options = {type, seats, title, isPrivate, modernOnly, totalChaos,picksPerPack};
+    let options = { type, seats, title, isPrivate, modernOnly, totalChaos, picksPerPack };
 
     switch (gamesubtype) {
-    case "regular": {
-      const {setsDraft, setsSealed} = App.state;
-      options.sets = gametype === "sealed" ? setsSealed : setsDraft;
-      break;
-    }
-    case "decadent":
-      options.sets = App.state.setsDecadentDraft;
-      break;
-    case "cube":
-      options.cube = parseCubeOptions();
-      break;
-    case "chaos":
-      options.chaosPacksNumber = /draft/.test(gametype) ? chaosDraftPacksNumber : chaosSealedPacksNumber;
-      break;
+      case "regular": {
+        const { setsDraft, setsSealed, burnsPerPack } = App.state;
+        options.sets = gametype === "sealed" ? setsSealed : setsDraft;
+        options.cube = {};
+        options.cube.burnsPerPack = parseInt(burnsPerPack);
+        break;
+      }
+      case "decadent":
+        options.sets = App.state.setsDecadentDraft;
+        break;
+      case "cube":
+        options.cube = parseCubeOptions();
+        break;
+      case "chaos":
+        options.chaosPacksNumber = /draft/.test(gametype) ? chaosDraftPacksNumber : chaosSealedPacksNumber;
+        break;
     }
     App.send("create", options);
   },
@@ -314,7 +317,7 @@ const events = {
 Object.keys(events).forEach((event) => App.on(event, events[event]));
 
 const parseCubeOptions = () => {
-  let {list, cards, packs, cubePoolSize, burnsPerPack} = App.state;
+  let { list, cards, packs, cubePoolSize, burnsPerPack } = App.state;
   cards = Number(cards);
   packs = Number(packs);
   cubePoolSize = Number(cubePoolSize);
@@ -329,7 +332,7 @@ const parseCubeOptions = () => {
     .filter(x => x)
     .join("\n");
 
-  return {list, cards, packs, cubePoolSize, burnsPerPack};
+  return { list, cards, packs, cubePoolSize, burnsPerPack };
 };
 
 const clickPack = (card) => {
@@ -354,7 +357,7 @@ const collectDeck = () => ({
   [ZONE_SIDEBOARD]: collectByName(App.state.gameState.get(ZONE_SIDEBOARD), true)
 });
 
-function collectByName (cards, sideboard = false) {
+function collectByName(cards, sideboard = false) {
   const collector = cards.reduce((acc, card) => {
     if (acc[card.name]) acc[card.name].count += 1;
     else acc[card.name] = { card, count: 1, sideboard };

--- a/frontend/src/lobby/GameOptions.jsx
+++ b/frontend/src/lobby/GameOptions.jsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
 import _ from "utils/utils";
@@ -10,35 +10,36 @@ import SelectSet from "./SelectSet";
 import CubeList from "./CubeList";
 
 const GameOptions = () => {
-  const { 
-      setsDraft, setsSealed, setsDecadentDraft, 
-      gametype, gamesubtype, 
-      picksPerPack} = App.state;
+  const {
+    setsDraft, setsSealed, setsDecadentDraft,
+    gametype, gamesubtype,
+    picksPerPack } = App.state;
 
   switch (`${gamesubtype} ${gametype}`) {
-  case "regular draft":
-    return <RegularDraft sets={setsDraft} type={"setsDraft"}  picksPerPack={picksPerPack}/>;
-  case "regular sealed":
-    return <RegularSealed sets={setsSealed} type={"setsSealed"} />;
-  case "decadent draft":
-    return <Decadent sets={setsDecadentDraft} type={"setsDecadentDraft"} picksPerPack={picksPerPack}/>;
-  case "cube draft":
-    return <CubeDraft picksPerPack={picksPerPack} />;
-  case "cube sealed":
-    return <CubeSealed />;
-  case "chaos draft":
-    return <ChaosDraft picksPerPack={picksPerPack} />;
-  case "chaos sealed":
-    return <ChaosSealed />;
-  default:
-    return null;
+    case "regular draft":
+      return <RegularDraft sets={setsDraft} type={"setsDraft"} picksPerPack={picksPerPack} />;
+    case "regular sealed":
+      return <RegularSealed sets={setsSealed} type={"setsSealed"} />;
+    case "decadent draft":
+      return <Decadent sets={setsDecadentDraft} type={"setsDecadentDraft"} picksPerPack={picksPerPack} />;
+    case "cube draft":
+      return <CubeDraft picksPerPack={picksPerPack} />;
+    case "cube sealed":
+      return <CubeSealed />;
+    case "chaos draft":
+      return <ChaosDraft picksPerPack={picksPerPack} />;
+    case "chaos sealed":
+      return <ChaosSealed />;
+    default:
+      return null;
   }
 };
 
-const RegularDraft = ({sets, type, picksPerPack}) => (
+const RegularDraft = ({ sets, type, picksPerPack }) => (
   <div>
     <Regular sets={sets} type={type} />
     <PicksPerPacks picksPerPack={picksPerPack} />
+    <BurnsPerPacks />
   </div>
 );
 
@@ -47,7 +48,7 @@ RegularDraft.propTypes = {
   type: PropTypes.string
 };
 
-const RegularSealed = ({sets, type}) => (
+const RegularSealed = ({ sets, type }) => (
   <Regular sets={sets} type={type} />
 );
 
@@ -56,14 +57,14 @@ RegularSealed.propTypes = {
   type: PropTypes.string
 };
 
-const Regular = ({sets, type}) => (
+const Regular = ({ sets, type }) => (
   <Fragment>
     <div>
       Number of packs:{" "}
       <Select
         value={sets.length}
         onChange={App._emit("changeSetsNumber", type)}
-        opts={_.seq(12, 1)} />
+        opts={_.seq(36, 1)} />
     </div>
     <div>
       <Sets sets={sets} type={type} />
@@ -76,7 +77,7 @@ Regular.propTypes = {
   type: PropTypes.string
 };
 
-const Sets = ({sets, type}) => (
+const Sets = ({ sets, type }) => (
   sets.map((set, i) => {
     return (
       <SelectSet
@@ -91,7 +92,7 @@ const Sets = ({sets, type}) => (
   })
 );
 
-const Decadent = ({sets, type, picksPerPack}) => (
+const Decadent = ({ sets, type, picksPerPack }) => (
   <Fragment>
     <div>
       Number of packs:{" "}
@@ -121,7 +122,7 @@ Decadent.propTypes = {
   type: PropTypes.string
 };
 
-const CubeDraft = ({picksPerPack}) => (
+const CubeDraft = ({ picksPerPack }) => (
   <div>
     <CubeList />
     <CubeOptions />
@@ -157,7 +158,7 @@ const CubeOptions = () => (
   </div>
 );
 
-const ChaosDraft = ({picksPerPack}) => (
+const ChaosDraft = ({ picksPerPack }) => (
   <div>
     <Chaos packsNumber={"chaosDraftPacksNumber"} />
     <PicksPerPacks picksPerPack={picksPerPack} />
@@ -168,29 +169,29 @@ const ChaosSealed = () => (
   <Chaos packsNumber={"chaosSealedPacksNumber"} />
 );
 
-const PicksPerPacks = ({picksPerPack}) => (
+const PicksPerPacks = ({ picksPerPack }) => (
   <div>
-  Picks per pack:{" "}
-  <Select
-    value={picksPerPack}
-    onChange={App._emit("changePicksPerPack")}
-    opts={_.seq(12, 1)} />
+    Picks per pack:{" "}
+    <Select
+      value={picksPerPack}
+      onChange={App._emit("changePicksPerPack")}
+      opts={_.seq(12, 1)} />
   </div>
 )
 
 const BurnsPerPacks = () => (
   <div>
     Burns per pack:{" "}
-    <Select link={"burnsPerPack"} opts={_.seq(4, 0)} /> 
+    <Select link={"burnsPerPack"} opts={_.seq(4, 0)} />
   </div>
 );
 
-const Chaos = ({packsNumber}) => (
+const Chaos = ({ packsNumber }) => (
   <div>
     <div>
       Number of packs:{" "}
       <Select
-        onChange={(e) => {App.save(packsNumber, parseInt(e.currentTarget.value));}}
+        onChange={(e) => { App.save(packsNumber, parseInt(e.currentTarget.value)); }}
         link={packsNumber}
         opts={_.seq(12, 3)} />
     </div>

--- a/scripts/custom_set_validate.js
+++ b/scripts/custom_set_validate.js
@@ -1,0 +1,6 @@
+const parser = require('../backend/import/xml/parser');
+const fs = require('fs');
+console.log(process.argv);
+const xml = fs.readFileSync(process.argv[2], 'utf8');
+console.log(xml);
+console.log(parser.parse(xml));

--- a/scripts/custom_sets/inject_picurls.js
+++ b/scripts/custom_sets/inject_picurls.js
@@ -1,0 +1,33 @@
+if (process.argv.length !== 4) {
+  console.error("You need to supply XML to inject PICURLS into as 1st argument and URL to the *root* of images folder as the 2nd argument.");
+  process.exit();
+}
+
+const parsethere = require('fast-xml-parser');
+const parseback = require('fast-xml-parser').j2xParser;
+const fs = require('fs');
+
+const options_there = {
+  ignoreAttributes: false,
+  ignoreNameSapce: false,
+  textNodeName: 'text'
+};
+const there = parsethere.parse(
+  fs.readFileSync(process.argv[2], 'utf8').replace(/<!-->Tokens<\/-->/g, ''),
+  options_there
+);
+
+const { cards } = there.cockatrice_carddatabase;
+cards.card.forEach(c => {
+  c.set['@_picurl'] = process.argv[3] + '/' + c.set.text + '/' + c.name + '.full.jpg';
+});
+
+const options_back = {
+  format: true,
+  ignoreAttributes: false,
+  textNodeName: 'text'
+}
+const back = new parseback(options_back);
+
+const xml = back.parse(there);
+console.log(xml);

--- a/scripts/custom_sets/validate.js
+++ b/scripts/custom_sets/validate.js
@@ -1,4 +1,4 @@
-const parser = require('../backend/import/xml/parser');
+const parser = require('../../backend/import/xml/parser');
 const fs = require('fs');
 console.log(process.argv);
 const xml = fs.readFileSync(process.argv[2], 'utf8');


### PR DESCRIPTION
## Linked tickets
No linked ticket.

## Explanation of the issue
It's hard for MSE users to playtest their sets on dr4fts. For instance, even if they would host images on some FTP, it would require them a lot of manual work to modify XML by hand.


## Description of your changes
We provide a complementary script for MSE users they can call to validate their XML for compliance with dr4ft, as well as the **a script they can call to inject picurls** making playtesting more fun!

It also adds a check for things that are tokens and short-ciruits cards.card loop in parser.js.

This PR also significantly improves the upload UX by saying which set number in XML broke the upload and which card name didn't pass checks.

## Screenshots

![image](https://user-images.githubusercontent.com/66186054/151898027-9978b0b8-28c9-43cd-8522-c0ed442de532.png)

