### PR TITLE
Mobile friendly

### DIFF
--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 
 import ReactTooltip from "react-tooltip";
 
+import "./Modal.scss";
+
 const Modal = ({
   headerText,
   footerConfirmButtonText,
@@ -17,7 +19,7 @@ const Modal = ({
   }
 
   return (
-    <div onScroll={() => {ReactTooltip.rebuild();}} className="modal-outer-container">
+    <div onScroll={() => {ReactTooltip.rebuild();}} className="Modal">
       <div className="modal-backdrop" onClick={onClose}></div>
       <div className="modal-container">
         <header className="modal-header">
@@ -41,7 +43,7 @@ const Modal = ({
         </header>
         <div className="modal-body">{children}</div>
         <div className="modal-footer">
-          <button onClick={onClose}>{footerCancelButtonText || "Cancel"}</button>
+          <button onClick={onClose} className="secondary">{footerCancelButtonText || "Cancel"}</button>
           <button onClick={onConfirm} className="primary">{footerConfirmButtonText || "Confirm"}</button>
         </div>
       </div>

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -19,7 +19,7 @@ const Modal = ({
   }
 
   return (
-    <div onScroll={() => {ReactTooltip.rebuild();}} className="Modal">
+    <div className="Modal" onScroll={() => ReactTooltip.rebuild()}>
       <div className="modal-backdrop" onClick={onClose}></div>
       <div className="modal-container">
         <header className="modal-header">
@@ -48,7 +48,14 @@ const Modal = ({
         </div>
       </div>
 
-      <ReactTooltip className="modal-tooltip" effect="solid" type="info" place="bottom" backgroundColor='#079DFF' textColor='#202124' />
+      <ReactTooltip
+        className="modal-tooltip"
+        effect="solid"
+        type="info"
+        place="bottom"
+        backgroundColor='#079DFF'
+        textColor='white'
+      />
     </div>
   );
 };

--- a/frontend/src/components/Modal.scss
+++ b/frontend/src/components/Modal.scss
@@ -26,7 +26,7 @@
 
     width: 960px;
     max-width: 90vw;
-    max-height: 100vh;
+    max-height: 90vh;
     overflow-y: auto;
 
     background: #FAFBFC;
@@ -174,6 +174,7 @@
         border: 1px solid #079DFF;
       }
       &.secondary {
+        background: none;
         color: rgba(0,0,0,0.7);
         border: 1px solid rgba(0,0,0,0);
         &:hover {

--- a/frontend/src/components/Modal.scss
+++ b/frontend/src/components/Modal.scss
@@ -1,0 +1,181 @@
+.Modal {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999999;
+
+  .modal-backdrop {
+    background: rgba(31, 31, 31, .72);
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  display: grid;
+  justify-content: center;
+
+  .modal-container {
+    width: 960px;
+    max-width: 90%;
+    height: 900px;
+    max-height: 90%;
+    overflow-y: auto;
+
+    background: #FAFBFC;
+    color: #24292E;
+
+    border-radius: 5px;
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+
+    a, a:visited { color: #079DFF; }
+
+    fieldset {
+      padding: 0;
+      border: 0;
+    }
+
+    input, textarea, select {
+      background: #F1F2F3;
+      color: #24292E;
+      border-color: #D9DBDB;
+      border-radius: 5px;
+      padding: 12px;
+      margin-bottom: 10px;
+    }
+
+    input:focus, textarea:focus, select:focus {
+      outline: none;
+      border-color: #079DFF;
+    }
+
+    input.error, textarea.error, select.error {
+      border-color: #E15252;
+      color: #E15252;
+    }
+
+    select {
+      padding: 12px 30px 12px 12px;
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
+      background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23079DFF%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E');
+      background-repeat: no-repeat, repeat;
+      background-position: right .7em top 50%, 0 0;
+      background-size: .65em auto, 100%;
+    }
+
+    input::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+      color: #868788;
+      opacity: 1; /* Firefox */
+    }
+
+    input:-ms-input-placeholder { /* Internet Explorer 10-11 */
+      color: #868788;
+    }
+
+    input::-ms-input-placeholder { /* Microsoft Edge */
+      color: #868788;
+    }
+
+    .modal-close-button {
+      position: absolute;
+      right: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+  }
+  @media screen and (max-width: 480px) {
+    .modal-container {
+      max-width: 100%;
+      max-height: 100%;
+
+
+      border-radius: 0;
+    }
+  }
+
+  .modal-header {
+    position: relative;
+    padding: 20px;
+    background: #F1F2F3;
+
+    h2 {
+      font-family: Helvetica;
+      font-weight: normal;
+      margin: 0;
+    }
+  }
+
+  .modal-section {
+    border-bottom: 1px solid #D9DBDB;
+    padding: 20px;
+    display: flex;
+
+    label {
+      flex: 0 1 auto;
+      width: 100px;
+      font-size: 1.25rem;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .modal-body { border: 1px solid #D9DBDB; }
+  .modal-tooltip { opacity: 1 !important; }
+
+  .modal-footer {
+    position: relative;
+    background: #F1F2F3;
+
+    display: grid;
+    grid-template-columns: auto auto;
+    justify-content: right;
+    grid-gap: 1rem;
+
+    padding: 10px 20px;
+
+    button {
+      font-family: sans-serif;
+      font-size: 1.25rem;
+      text-align: center;
+      text-decoration: none;
+      cursor: pointer;
+
+      padding: 1rem 2rem;
+      border: 1px solid #586069;
+      border-radius: 4px;
+
+      transition: background 250ms ease-in-out, 
+      transform 150ms ease;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+
+      &.primary {
+        color: #079DFF;
+        border: 1px solid #079DFF;
+      }
+      &.secondary {
+        color: rgba(0,0,0,0.7);
+        border: 1px solid rgba(0,0,0,0);
+        &:hover {
+          transition: color .5s ease;
+          color: rgba(255,0,0,1);
+        }
+      }
+      &:focus {
+        outline: 1px solid #079DFF;
+        outline-offset: -2px;
+      }
+      &:active {
+        transform: scale(0.99);
+      }
+    }
+  }
+}

--- a/frontend/src/components/Modal.scss
+++ b/frontend/src/components/Modal.scss
@@ -16,13 +16,17 @@
   }
 
   display: grid;
-  justify-content: center;
+  grid-template-rows: 1fr auto 2fr;
+  justify-items: center;
+  align-items: start;
 
   .modal-container {
+    grid-row: 2;
+    z-index: 1;
+
     width: 960px;
-    max-width: 90%;
-    height: 900px;
-    max-height: 90%;
+    max-width: 90vw;
+    max-height: 100vh;
     overflow-y: auto;
 
     background: #FAFBFC;
@@ -91,9 +95,8 @@
   }
   @media screen and (max-width: 480px) {
     .modal-container {
-      max-width: 100%;
-      max-height: 100%;
-
+      max-width: 100vw;
+      max-height: 100vh;
 
       border-radius: 0;
     }
@@ -104,27 +107,36 @@
     padding: 20px;
     background: #F1F2F3;
 
+    @media screen and (max-width: 440px) {
+      padding: 15px;
+    }
+
     h2 {
       font-family: Helvetica;
+      font-size: 1rem;
       font-weight: normal;
       margin: 0;
     }
   }
 
   .modal-section {
-    border-bottom: 1px solid #D9DBDB;
     padding: 20px;
-    display: flex;
+    border-bottom: 1px solid #D9DBDB;
+    &:last-child { border-bottom: none; }
+
+    display: grid;
+    grid-template-columns: 100px 1fr;
+
+    @media screen and (max-width: 440px) {
+      padding: 15px;
+      grid-template-columns: 1fr;
+    }
 
     label {
-      flex: 0 1 auto;
-      width: 100px;
       font-size: 1.25rem;
+      margin-bottom: 1rem;
     }
-
-    &:last-child {
-      border-bottom: none;
-    }
+    .modal-section-content {}
   }
 
   .modal-body { border: 1px solid #D9DBDB; }

--- a/frontend/src/components/Modal.scss
+++ b/frontend/src/components/Modal.scss
@@ -40,6 +40,9 @@
     fieldset {
       padding: 0;
       border: 0;
+
+      display: grid;
+      justify-content: start;
     }
 
     input, textarea, select {
@@ -140,7 +143,16 @@
   }
 
   .modal-body { border: 1px solid #D9DBDB; }
-  .modal-tooltip { opacity: 1 !important; }
+  .modal-tooltip {
+
+    letter-spacing: 0.5px;
+
+    opacity: 1 !important;
+    padding: 10px 12px;
+    border-radius: 8px;
+  }
+  // NOTE this is the class assigned to the react-tooltips
+  // see <ReactToolTip ... /> use in ./Modal.jsx
 
   .modal-footer {
     position: relative;

--- a/frontend/src/components/Switch.jsx
+++ b/frontend/src/components/Switch.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import App from "../app";
+
+import "./Switch.scss";
+
+const Switch = ({
+  appProperty,
+  checked,
+  unchecked
+}) => {
+  const isChecked = Boolean(App.state[appProperty])
+  const { label, tooltip } = isChecked ? checked : unchecked
+
+
+  return (
+    <label className="Switch">
+      <span className='label'>{label}</span>
+      <span className="vhidden">({tooltip})</span>
+
+      <input
+        type="checkbox"
+        checked={isChecked}
+        onChange={() => {
+          App.save(appProperty, !isChecked);
+        }}
+      />
+      <span className="slider-nob round"></span>
+      <span className="slider round"></span>
+    </label>
+  );
+};
+
+Switch.propTypes = {
+  appProperty: PropTypes.string,
+  checked: PropTypes.object,
+  unchecked: PropTypes.object,
+  tooltip: PropTypes.string
+};
+
+export default Switch;

--- a/frontend/src/components/Switch.jsx
+++ b/frontend/src/components/Switch.jsx
@@ -7,24 +7,21 @@ import "./Switch.scss";
 
 const Switch = ({
   appProperty,
-  checked,
-  unchecked
+  checked = {},
+  unchecked = {}
 }) => {
   const isChecked = Boolean(App.state[appProperty])
-  const { label, tooltip } = isChecked ? checked : unchecked
-
+  const tooltip = (isChecked ? checked : unchecked).tooltip
 
   return (
-    <label className="Switch">
-      <span className='label'>{label}</span>
+    <label className="Switch" data-tip={tooltip}>
+      <span className='label'>Private</span>
       <span className="vhidden">({tooltip})</span>
 
       <input
         type="checkbox"
         checked={isChecked}
-        onChange={() => {
-          App.save(appProperty, !isChecked);
-        }}
+        onChange={() => App.save(appProperty, !isChecked) }
       />
       <span className="slider-nob round"></span>
       <span className="slider round"></span>

--- a/frontend/src/components/Switch.scss
+++ b/frontend/src/components/Switch.scss
@@ -1,0 +1,71 @@
+.Switch {
+	display: grid;
+
+  grid-template-columns: 60px auto;
+  grid-template-rows: 34px;
+  align-content: center;
+  align-items: center;
+
+  grid-gap: 10px;
+
+  .slider {
+    grid-row: 1;
+    grid-column: 1;
+
+    height: 34px;
+    width: 60px;
+
+    cursor: pointer;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+
+    &.round { border-radius: 34px; }
+  }
+  .slider-nob {
+    z-index: 10;
+    grid-row: 1;
+    grid-column: 1;
+
+    content: "";
+    height: 26px;
+    width: 26px;
+
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+
+    margin-left: calc(calc(34px - 26px) / 2);
+
+    &.round { border-radius: 26px; }
+  }
+
+  .label {
+    grid-column: 2;
+    font-size: 1rem;
+  }
+
+  input:checked + .slider-nob {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+  input:checked ~ .slider {
+    background-color: #2196F3;
+  }
+
+  input {
+    grid-row: 1;
+    grid-column: 1;
+		opacity: 0;
+		width: 0;
+		height: 0;
+    &:focus {
+      + {
+        .slider {
+          box-shadow: 0 0 1px #2196F3;
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/game/Cols.scss
+++ b/frontend/src/game/Cols.scss
@@ -1,6 +1,6 @@
 .Cols {
   --card-width: 180px;
-  --card-height: 255px;
+  --card-width: calc(180px * 17 / 12);
 
   .col {
     float: left;

--- a/frontend/src/game/Cols.scss
+++ b/frontend/src/game/Cols.scss
@@ -1,6 +1,6 @@
 .Cols {
   --card-width: 180px;
-  --card-width: calc(180px * 17 / 12);
+  --card-height: calc(180px * 17 / 12);
 
   .col {
     float: left;
@@ -30,5 +30,17 @@
 
     --card-width: 240px;
     --card-height: 340px;
+  }
+
+  /* over-rides to chill out the deck building area */
+  .CardBase {
+    .CardBaseText, .CardBaseImage {
+      img {
+        &.loading {
+          opacity: 1;
+          transform: none;
+        }
+      }
+    }
   }
 }

--- a/frontend/src/game/Grid.jsx
+++ b/frontend/src/game/Grid.jsx
@@ -51,6 +51,8 @@ const Zone = ({ name: zoneName }) => {
   const canConfirm = gameState.isSelectionReady(remainingCardsToSelect, remainingCardsToBurn)
   const cardsInNextPack = packSize - (pickNumber * (picksPerPack + game.burnsPerPack)) % packSize
 
+  const showPicksDetail = game.picksPerPack > 1 || game.burnsPerPack > 0
+  const showBurnsDetail = game.burnsPerPack > 0
   return (
     <div className='Grid zone'>
       <div className='header'>
@@ -61,19 +63,19 @@ const Zone = ({ name: zoneName }) => {
           ]} />
         </h1>
 
-        <div className='pick-burn-detail'>
-          {
-            (
-              game.picksPerPack > 1 ||
-              game.burnsPerPack > 0
-            ) &&
-              <span className="picks">{`Pick ${remainingCardsToSelect}`}</span>
-          }
-          {
-            game.burnsPerPack > 0 &&
-              <span className="burns">{`Burn ${remainingCardsToBurn}`}</span>
-          }
-        </div>
+        {
+          (showPicksDetail || showBurnsDetail) &&
+          <div className='pick-burn-detail'>
+            {
+              showPicksDetail &&
+              <div className="picks">{`Pick ${remainingCardsToSelect}`}</div>
+            }
+            {
+              showBurnsDetail &&
+              <div className="burns">{`Burn ${remainingCardsToBurn}`}</div>
+            }
+          </div>
+        }
 
         {
           cards.length > 0 && zoneName === ZONE_PACK &&

--- a/frontend/src/game/Grid.scss
+++ b/frontend/src/game/Grid.scss
@@ -1,39 +1,40 @@
 .Grid {
-  --card-width: 240px;
-  --card-height: 334.2px;
-
   margin-bottom: 20px;
 
   > .header {
+    margin: 1rem 0;
+
     display: grid;
-    grid-template-columns: auto auto auto;
+    grid-auto-flow: column;
     justify-content: start;
     justify-items: start;
     grid-gap: 1rem;
 
     h1 {
+      margin: 0
     }
 
     .pick-burn-detail, .confirm-btn {
-      margin: 28px 0;
     }
 
     .pick-burn-detail {
       font-size: 1rem;
-      font-weight: bold;
+      // font-weight: bold;
 
-      display: grid;
-      grid-auto-flow: column;
-      grid-gap: 14px;
-      align-content: end;
+      max-width:  20vw; // this 
 
-      .picks, .burns {
-      }
+      display: flex;
+      flex-wrap: wrap;
+      align-content: flex-end;
+      align-items: flex-end;
+
+      .picks { padding-right: 6px; }
+      .burns { }
     }
 
     button.confirm-btn {
-      justify-self: center;
-      align-self: center;
+      justify-self: start;
+      align-self: end;
 
       font-size: 18px;
       color: #fff;
@@ -42,8 +43,7 @@
 
       border: #3a87e5 solid 1px;
       border-radius: 2px;
-
-      margin-left: 1rem;
+      margin-bottom: 3px;
     }
     button[disabled].confirm-btn {
       color: #777;
@@ -72,3 +72,11 @@
     }
   }
 }
+
+@media screen and (max-width: 480px) {
+  .Grid {
+    --card-width: calc(100vw / 2 - 5px);
+    --card-height: calc(calc(100vw / 2 - 5px) * 17 / 12);
+  }
+}
+

--- a/frontend/src/game/PlayersPanel.jsx
+++ b/frontend/src/game/PlayersPanel.jsx
@@ -2,13 +2,14 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 
 import App from "../app";
+import "./PlayersPanel.scss"
 
 const PlayersPanel = () => (
-  <fieldset className='fieldset'>
+  <fieldset className='PlayersPanel fieldset'>
     <legend className='legend game-legend'>Players ({App.state.players.length}/{App.state.gameSeats})</legend>
     <PlayersTable />
     <div id='self-time-fixed' hidden>
-      <u>Time Left</u>
+      <div className='label'>Time left</div>
       <div id='self-time-fixed-time' />
     </div>
   </fieldset>
@@ -66,7 +67,7 @@ const fixPackTimeToScreen = () => {
     const zoneRect = zone.getBoundingClientRect();
     const selfTimeRect = selfTimeFixed.getBoundingClientRect();
     selfTimeFixed.hidden = !(App.state.round > 0 && selfRect.top < 0);
-    selfTimeFixed.style.left = `${zoneRect.right - selfTimeRect.width - 5}px`;
+    selfTimeFixed.style.left = `${zoneRect.right - selfTimeRect.width}px`;
     selfTimeFixed.style.top
     = zoneRect.top > 0
         ? `${zoneRect.top + 5}px`

--- a/frontend/src/game/PlayersPanel.scss
+++ b/frontend/src/game/PlayersPanel.scss
@@ -1,0 +1,35 @@
+.PlayersPanel {
+
+  #self-time-fixed {
+    position: fixed;
+    z-index: 99;
+
+    background-color: rgba(255, 255, 255, 0.63);
+
+    height: 44px;
+    min-width: 62px;
+
+    padding: 4px;
+    border: solid 1px white;
+    border-right: none;
+    // border-radius: 4px;
+
+    transition: left 0.5s;
+
+    > .label, > #self-time-fixed-time {
+      filter: drop-shadow(white 0 0 2px);
+    }
+
+    > .label {
+      font-size: 16px;
+      text-align: center;
+    }
+
+    > #self-time-fixed-time {
+      font-size: 20px;
+
+      margin-left: 39%;
+      margin-top: 4px;
+    }
+  }
+}

--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -157,13 +157,13 @@
 
 .CardBaseImage {
   width: var(--card-width);
-  height: calc(var(--card-height));
+  height: var(--card-height);
 
   img {
     width: var(--card-width);
-    height: calc(var(--card-height));
+    height: var(--card-height);
     max-width: var(--card-width);
-    max-height: calc(var(--card-height));
+    max-height: var(--card-height);
     border-radius: 10px;
   }
 }

--- a/frontend/src/game/card/CardBase.scss
+++ b/frontend/src/game/card/CardBase.scss
@@ -157,13 +157,13 @@
 
 .CardBaseImage {
   width: var(--card-width);
-  height: var(--card-height);
+  height: calc(var(--card-height));
 
   img {
     width: var(--card-width);
-    height: var(--card-height);
+    height: calc(var(--card-height));
     max-width: var(--card-width);
-    max-height: var(--card-height);
+    max-height: calc(var(--card-height));
     border-radius: 10px;
   }
 }

--- a/frontend/src/game/card/CardDefault.scss
+++ b/frontend/src/game/card/CardDefault.scss
@@ -1,5 +1,5 @@
 .CardDefault {
-  --pick-color: #00d400;
+  --pick-color: #2ba62b;
 
   position: relative;
 

--- a/frontend/src/game/card/CardGlimpse.scss
+++ b/frontend/src/game/card/CardGlimpse.scss
@@ -1,7 +1,4 @@
 .CardGlimpse {
-  --card-width: 240px;
-  --card-height: 334.2px;
-
   --btn-size: 40px;
 
   --pick-color: #00d400;

--- a/frontend/src/lobby/CreateGameButton.jsx
+++ b/frontend/src/lobby/CreateGameButton.jsx
@@ -1,14 +1,16 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
-
 import _ from "utils/utils";
+
 import App from "../app";
 import RadioOptions from "../components/RadioOptions";
-import Modal from "../components/Modal";
-
+import Switch from "../components/Switch";
+import Modal from "../components/Modal"; 
 import { toTitleCase } from "../utils";
 import GameTypes from "./GameTypes";
 import GameOptions from "./GameOptions";
+
+import "./CreateGameButton.scss"
 
 // set this out here so the create button has the capability
 // to open the modal
@@ -23,7 +25,7 @@ const ModalSection = (props) => {
   return (
     <div className="modal-section">
       <label htmlFor={props.inputId}>{props.label}</label>
-      <div className="modal-section-content">{props.children}</div>
+      <div className={"modal-section-content " + props.className}>{props.children}</div>
     </div>
   );
 };
@@ -32,6 +34,7 @@ ModalSection.propTypes = {
   hide: PropTypes.bool,
   label: PropTypes.string,
   inputId: PropTypes.string,
+  className: PropTypes.string,
   children: PropTypes.node
 };
 
@@ -64,10 +67,7 @@ const CreateRoomModal = () => {
       onClose={closeModal}
       onConfirm={App._emit("create")}
     >
-      <ModalSection
-        label="Title"
-        inputId="game-title-input"
-      >
+      <ModalSection label="Title" inputId="game-title-input" >
         <input type='text'
           ref={draftNameInput}
           id="game-title-input"
@@ -96,70 +96,53 @@ const CreateRoomModal = () => {
           </span>
         </div>
       </ModalSection>
-      <ModalSection
-        label="Players"
-        inputId="game-players-input"
-      >
+
+      <ModalSection label="Players" inputId="game-players-input" className="Players" >
         <select id="game-players-input" value={seats} onChange={(e) => {App.save("seats", e.currentTarget.value);}}>
           {_.seq(100, 1).map((x, i) =>
             <option key={i}>{x}</option>)}
         </select>
-        <RadioOptions
-          name="public-private"
-          description="Create a public or private game"
+
+        <Switch
           appProperty="isPrivate"
-          options={[{
-            label: "Public",
-            value: false,
-            tooltip: "Anyone can join"
-          }, {
+          checked={{
             label: "Private",
-            value: true,
-            tooltip: "A link is required to join"
-          }]}
+            tooltip: "A link is required"
+          }}
+          unchecked={{
+            label: "Public",
+            tooltip: "Anyone can join"
+          }}
         />
       </ModalSection>
-      <ModalSection
-        label="Type"
-        inputId="game-type-input"
-      >
+
+      <ModalSection label="Type" inputId="game-type-input" >
         <GameTypes/>
       </ModalSection>
-      <ModalSection
-        label="Packs"
-        inputId="game-packs-input"
-      >
+
+      <ModalSection label="Packs" inputId="game-packs-input" >
         <GameOptions/>
       </ModalSection>
+
       {/* TODO This probably needs a better design, but for now, just show all app errors here since most of them at this stage will be about the room setup failing */}
-      <ModalSection
-        hide={!App.err}
-        label="Error"
-      >
+      <ModalSection hide={!App.err} label="Error" >
         <p dangerouslySetInnerHTML={{__html: App.err}} className='error' />
       </ModalSection>
     </Modal>
   );
 };
 
-const CreatePanel = () => {
+const CreateGameButton = () => {
   createModalButtonRef = useRef(null);
 
   return (
-    <fieldset className='fieldset'>
-      <legend className='legend'>
-        Create a Room
-      </legend>
+    <div className="CreateGameButton">
       <CreateRoomModal />
-      <p>
-        <button ref={createModalButtonRef} onClick={e => {
-          showModal();
-        }}>
-          Create Room
-        </button>
-      </p>
-    </fieldset>
-  );
+      <button ref={createModalButtonRef} onClick={e => showModal()}>
+        Create Game
+      </button>
+    </div>
+  )
 };
 
-export default CreatePanel;
+export default CreateGameButton;

--- a/frontend/src/lobby/CreateGameButton.jsx
+++ b/frontend/src/lobby/CreateGameButton.jsx
@@ -62,12 +62,12 @@ const CreateRoomModal = () => {
   return (
     <Modal
       show={open}
-      headerText="Create"
+      headerText="Create Game"
       footerConfirmButtonText="Create"
       onClose={closeModal}
       onConfirm={App._emit("create")}
     >
-      <ModalSection label="Title" inputId="game-title-input" >
+      <ModalSection label="Name" inputId="game-title-input" >
         <input type='text'
           ref={draftNameInput}
           id="game-title-input"

--- a/frontend/src/lobby/CreateGameButton.scss
+++ b/frontend/src/lobby/CreateGameButton.scss
@@ -19,4 +19,19 @@
 
     select, label { margin: 0; }
   }
+
+
+  #cube-list {
+    display: flex;
+    flex-direction: column;
+  }
+  .cube-list {
+    width: 90%;
+    height: 150px;
+    overflow-y: scroll;
+
+    font-size: 14px;
+    line-height: 18px;
+  }
+
 }

--- a/frontend/src/lobby/CreateGameButton.scss
+++ b/frontend/src/lobby/CreateGameButton.scss
@@ -1,0 +1,22 @@
+.CreateGameButton {
+  button {
+    color: #089dff;
+    background: white;
+    cursor: pointer;
+
+    padding: 10px 20px;
+    border: 1px solid #089dff;
+    margin-top: 1rem;
+  }
+
+  .Players {
+    display: grid;
+    grid-template-columns: 100px auto;
+    grid-gap: 1rem;
+
+    align-items: center;
+    justify-content: start;
+
+    select, label { margin: 0; }
+  }
+}

--- a/frontend/src/lobby/GamesPanel.jsx
+++ b/frontend/src/lobby/GamesPanel.jsx
@@ -1,12 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const JoinPanel = ({roomInfo}) => {
+import CreateGameButton from "./CreateGameButton";
+
+import "./GamesPanel.scss";
+
+const GamesPanel = ({roomInfo}) => {
   return (
-    <fieldset className='fieldset'>
-      <legend className='legend'>Join a Room</legend>
+    <fieldset className='GamesPanel fieldset'>
+      <legend className='legend'>Games</legend>
       {roomInfo.length
-        ? <table className='join-room-table'>
+        ? <table className='join-game-table'>
           <thead>
             <tr>
               <th>Name</th>
@@ -23,20 +27,21 @@ const JoinPanel = ({roomInfo}) => {
               <td>{room.packsInfo}</td>
               <td>{room.usedSeats}/{room.totalSeats}</td>
               <td>
-                <a href={`#g/${room.id}`} className='join-room-link'>
-                    Join room
+                <a href={`#g/${room.id}`} className='join-game-link'>
+                  <div>Join game</div>
                 </a>
               </td>
             </tr>)}
           </tbody>
         </table>
         : "There are no public rooms open currently."}
+      <CreateGameButton />
     </fieldset>
   );
 };
 
-JoinPanel.propTypes = {
+GamesPanel.propTypes = {
   roomInfo: PropTypes.array
 };
 
-export default JoinPanel;
+export default GamesPanel;

--- a/frontend/src/lobby/GamesPanel.scss
+++ b/frontend/src/lobby/GamesPanel.scss
@@ -1,0 +1,26 @@
+.GamesPanel {
+  .join-game-table {
+    border-collapse: collapse;
+    text-align: center;
+    width: 100%;
+
+    th, td { padding: 5px; }
+
+    tbody tr {
+      background-color: #f0f0f0;
+      border: solid #d0d0d0 1px;
+    }
+  }
+
+  .join-game-link {
+    text-decoration: none;
+
+    div {
+      color: #089dff;
+      background: white;
+      padding: 2px 9px;
+
+      &:after { content: '\00bb'; }
+    }
+  }
+}

--- a/frontend/src/lobby/Lobby.jsx
+++ b/frontend/src/lobby/Lobby.jsx
@@ -4,9 +4,8 @@ import App from "../app";
 import {STRINGS} from "../config";
 
 import Header from "./Header";
-import JoinPanel from "./JoinPanel";
+import GamesPanel from "./GamesPanel";
 import NewsPanel from "./NewsPanel";
-import CreatePanel from "./CreatePanel";
 import FileUpload from "./FileUpload";
 import Version from "./Version";
 
@@ -24,8 +23,7 @@ export default class Lobby extends Component {
       <div className="container">
         <div className="lobby">
           <Header/>
-          <CreatePanel/>
-          <JoinPanel roomInfo={roomInfo}/>
+          <GamesPanel roomInfo={roomInfo}/>
           <FileUpload />
           <NewsPanel motd={STRINGS.PAGE_SECTIONS.MOTD}/>
           {STRINGS.BRANDING.PAYPAL}

--- a/frontend/src/lobby/SelectSet.scss
+++ b/frontend/src/lobby/SelectSet.scss
@@ -102,49 +102,44 @@
     border: 1px solid #089dff;
     border-radius: 4px;
 
-    max-height: 300px;
+    // max-height: 300px;
     overflow-y: auto;
+    position: absolute;
+    z-index: 99999991;
   }
 
-  /**
-   * Options
-   */
   .SelectSet__options {
     list-style: none;
   }
 
-  /**
-   * Option row
-   */
   .SelectSet__row:not(:first-child) {
     border-top: 1px solid #eee;
   }
 
-  /**
-   * Option
-   */
   .SelectSet__option,
   .SelectSet__not-found {
-    display: grid;
-    justify-content: start;
-    align-content: center;
-    align-items: center;
-    grid-gap: 5px;
-
-    grid-auto-flow: column;
-    grid-template-columns: 24px 1fr auto;
-
     // display: block;
     height: 36px;
     width: 100%;
-    padding: 0 16px;
-    background: #fff;
-    border: none;
-    outline: none;
+
     font-family: 'Noto Sans', sans-serif;
     font-size: 14px;
     text-align: left;
     cursor: pointer;
+
+    padding: 0 16px;
+    background: #fff;
+    border: none;
+    outline: none;
+
+
+    display: grid;
+    grid-template-columns: 24px 1fr auto;
+    // grid-auto-flow: column;
+    grid-gap: 5px;
+    // justify-content: start;
+    align-content: center;
+    align-items: center;
 
     i {
      justify-self: center;

--- a/frontend/src/lobby/SelectSet.scss
+++ b/frontend/src/lobby/SelectSet.scss
@@ -10,6 +10,7 @@
 
 .SelectSet {
   width: 300px;
+  max-width: calc(100vw - 30px);
   position: relative;
   font-family: 'Nunito Sans', sans-serif;
   box-sizing: border-box;

--- a/frontend/src/lobby/SelectSet.scss
+++ b/frontend/src/lobby/SelectSet.scss
@@ -102,6 +102,7 @@
 
     border: 1px solid #089dff;
     border-radius: 4px;
+    width: 100%;
 
     // max-height: 300px;
     overflow-y: auto;
@@ -111,6 +112,7 @@
 
   .SelectSet__options {
     list-style: none;
+    width: 100%
   }
 
   .SelectSet__row:not(:first-child) {
@@ -154,7 +156,11 @@
   }
 
   .SelectSet__option {
+    color: rgba(0,0,0, 0.9);
+
+    padding: 0 12px;
     border-radius: 0;
+    margin: 0;
 
     &:not(.is-selected):hover {
       background: rgba(155, 47, 204, 0.15);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -281,10 +281,11 @@ input[type="checkbox"], input[type="radio"] {
 /** Lobby **/
 
 .lobby {
-  flex-grow: 1;
+  max-width: 900px;
   margin: 0 auto;
 
   display: flex;
+  flex-grow: 1;
   flex-direction: column;
 }
 
@@ -346,29 +347,6 @@ input[type="checkbox"], input[type="radio"] {
   margin-left: -1px;
   width: 100%;
 }
-
-/*** Join rooms ***/
-
-.join-room-table {
-  border-collapse: collapse;
-  text-align: center;
-  width: 100%;
-}
-
-.join-room-table th,
-.join-room-table td {
-  padding: 5px;
-}
-
-.join-room-table tbody tr {
-  background-color: #f0f0f0;
-  border: solid #d0d0d0 1px;
-}
-
-.join-room-link:after {
-  content: '\00bb';
-}
-
 /** Zones **/
 
 .waiting {
@@ -539,5 +517,7 @@ input[type="checkbox"], input[type="radio"] {
   font-size: 14px;
   line-height: 18px;
 }
-}
 
+.filepond--credits {
+  display: none;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -269,11 +269,6 @@ input[type="checkbox"], input[type="radio"] {
   }
 }
 
-#cube-list {
-  display: flex;
-  flex-direction: column;
-}
-
 #preset-cubes {
   margin-left: 4px;
 }
@@ -507,15 +502,6 @@ input[type="checkbox"], input[type="radio"] {
   margin-left: 0px;
   padding: 1px 1px 1px 10px;
   font-style: italic;
-}
-
-.cube-list {
-  width: 100%;
-  height: 150px;
-  overflow-y: scroll;
-
-  font-size: 14px;
-  line-height: 18px;
 }
 
 .filepond--credits {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -40,6 +40,9 @@ html,
 body {
   margin: 0;
   height: 100%;
+
+  --card-width: 240px;
+  --card-height: 340px;
 }
 
 body {
@@ -256,9 +259,14 @@ input[type="checkbox"], input[type="radio"] {
 .container {
   box-sizing: border-box;
   min-height: 100vh;
-  padding: 30px 0 30px 30px;
+  padding: 30px;
   display: flex;
   flex-direction: row;
+}
+@media screen and (max-width: 480px) {
+  .container {
+    padding: 4px;
+  }
 }
 
 #cube-list {
@@ -275,7 +283,6 @@ input[type="checkbox"], input[type="radio"] {
 .lobby {
   flex-grow: 1;
   margin: 0 auto;
-  padding-right: 30px;
 
   display: flex;
   flex-direction: column;
@@ -396,24 +403,6 @@ input[type="checkbox"], input[type="radio"] {
   background-color: rgba(0, 255, 0, .1);
 }
 
-#self-time-fixed {
-  border: solid 1px black;
-  position: fixed;
-  font-size: 20px;
-  padding: 4px;
-  min-width: 85px;
-  border-radius: 4px;
-  height: 44px;
-  background-color: rgba(255, 255, 255, 0.63);
-  transition: left 0.5s;
-  z-index: 99;
-}
-
-#self-time-fixed-time {
-  margin-left: 39%;
-  margin-top: 4px;
-}
-
 .opp {
   background-color: rgba(255, 0, 0, .1);
 }
@@ -447,12 +436,16 @@ input[type="checkbox"], input[type="radio"] {
 
 .game {
   flex-grow: 1;
-  padding-right: 30px;
+  max-width: 100%;
 }
 
 .game-controls {
-  display: flex;
+  max-width: 100vw;
+  overflow-x: auto;
+
   margin-bottom: 30px;
+
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 }
@@ -539,174 +532,12 @@ input[type="checkbox"], input[type="radio"] {
 }
 
 .cube-list {
-  overflow-y: "scroll";
+  width: 100%;
   height: 150px;
+  overflow-y: scroll;
+
+  font-size: 14px;
+  line-height: 18px;
+}
 }
 
-/* Modal Styles */
-.modal-outer-container {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 9999999;
-}
-
-.modal-backdrop {
-  background: rgba(31, 31, 31, .72);
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-.modal-close-button {
-  position: absolute;
-  right: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: pointer;
-}
-
-.modal-container {
-  width: 960px;
-  max-width: 90%;
-  background: #FAFBFC;
-  color: #24292E;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  max-height: 90%;
-  overflow-y: auto;
-  border-radius: 5px;
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
-}
-
-.modal-container a, .modal-container a:visited {
-  color: #079DFF;
-}
-
-.modal-container fieldset {
-  padding: 0;
-  border: 0;
-}
-
-.modal-container input, .modal-container textarea, .modal-container select {
-  background: #F1F2F3;
-  color: #24292E;
-  border-color: #D9DBDB;
-  border-radius: 5px;
-  padding: 12px;
-  margin-bottom: 10px;
-}
-
-.modal-container input:focus, .modal-container textarea:focus, .modal-container select:focus {
-  outline: none;
-  border-color: #079DFF;
-}
-
-.modal-container input.error, .modal-container textarea.error, .modal-container select.error {
-  border-color: #E15252;
-  color: #E15252;
-}
-
-.modal-container select {
-  padding: 12px 30px 12px 12px;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23079DFF%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E');
-  background-repeat: no-repeat, repeat;
-  background-position: right .7em top 50%, 0 0;
-  background-size: .65em auto, 100%;
-}
-
-.modal-container input::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
-  color: #868788;
-  opacity: 1; /* Firefox */
-}
-
-.modal-container input:-ms-input-placeholder { /* Internet Explorer 10-11 */
-  color: #868788;
-}
-
-.modal-container input::-ms-input-placeholder { /* Microsoft Edge */
-  color: #868788;
-}
-
-.modal-header, .modal-footer {
-  position: relative;
-  padding: 20px;
-  background: #F1F2F3;
-}
-
-.modal-header h2 {
-  font-family: Helvetica;
-  font-weight: normal;
-}
-
-.modal-footer {
-  text-align: right;
-}
-
-.modal-section {
-  border-bottom: 1px solid #D9DBDB;
-  padding: 20px;
-  display: flex;
-}
-
-.modal-section:last-child {
-  border-bottom: none;
-}
-
-.modal-section label {
-  flex: 0 1 auto;
-  width: 100px;
-  font-size: 1.25rem;
-}
-
-.modal-footer button {
-  font-size: 1.25rem;
-}
-
-.modal-container button {
-  display: inline-block;
-  border: 1px solid #586069;
-  padding: 1rem 2rem;
-  min-width: 170px;
-  margin: 0 0 0 25px;
-  text-decoration: none;
-  border-radius: 4px;
-  font-family: sans-serif;
-  cursor: pointer;
-  text-align: center;
-  transition: background 250ms ease-in-out, 
-  transform 150ms ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-}
-
-.modal-container button:focus {
-  outline: 1px solid #079DFF;
-  outline-offset: -2px;
-}
-
-.modal-container button:active {
-  transform: scale(0.99);
-}
-
-.modal-container button.primary {
-  color: #079DFF;
-  border-color: #079DFF;
-}
-
-.modal-body {
-  border: 1px solid #D9DBDB;
-}
- 
-.modal-tooltip {
-  opacity: 1 !important;
-}


### PR DESCRIPTION
## Explanation of the issue
The UI was a bit cluttered when using it in mobile. This is a first pass fixing that.


## Description of your changes

Changed the CSS of:
- **main drafting area** shrink to fit two columns of cards, drops page padding down
- **main game creating modal** so it fits on mobile

Component changes:
- on the home page, merged "create room + join room => Games"
    - pulling the sections together makes it very clear that making a game could put it in the list of games to join
    -  renaming rooms > games because ... what is a room but a game that's yet to start? Feels like a good simplification to me
- in the create game model, changed the public/ private selector to a **toggle** 

I'm keen to revisit some of the designs someone did and make this app really a delight to look at and use. 

## Screenshots

landing page | create game | draft 
---|---|---
![signal-2022-02-20-014755](https://user-images.githubusercontent.com/2665886/154801476-959290cd-a332-45ee-8803-5c9e081cf602.jpeg) | ![signal-2022-02-20-014537](https://user-images.githubusercontent.com/2665886/154801398-b76e502f-b04f-47de-83b8-47df6dfe80be.jpeg) | ![signal-2022-02-20-014529](https://user-images.githubusercontent.com/2665886/154801401-ee59388c-5948-40c5-8620-750a2aee7b4b.jpeg)

