### PR TITLE
Simpler footer

### DIFF
--- a/frontend/src/lobby/Version.jsx
+++ b/frontend/src/lobby/Version.jsx
@@ -13,21 +13,20 @@ const Version = ({version, MTGJSONVersion, boosterRulesVersion}) => {
   return (
     <div className="Version">
       <div>
-        dr4ft version: {" "}
+        <a href="https://github.com/dr4fters/dr4ft">dr4ft</a> {" "}
         <a href={`https://github.com/dr4fters/dr4ft/${getLink(version)}`} className='code'>
           <code>{version}</code>
         </a> <span className='date'>({BUILD_DATE})</span>
       </div>
 
       <div>
-        Card data: <a href="https://www.mtgjson.com">MTGJSON</a> {" "}
+        <a href="https://www.mtgjson.com">MTGJSON</a> {" "}
         <a href={`https://mtgjson.com/changelog/mtgjson-v5/#_${MTGJSONVersion.version.replace(/\./g, "-")}`} className='code'>
           <code>v{MTGJSONVersion.version}</code>
         </a> <span className='date'>({MTGJSONVersion.date})</span>
       </div>
 
       <div>
-        Booster rules: {" "}
         <a href={"https://github.com/taw/magic-sealed-data"}>Magic Sealed Data</a> {" "}
         <a href={`https://github.com/taw/magic-sealed-data/commit/${boosterRulesVersion}`} className='code'>
           <code>{boosterRulesVersion.substring(0, 7)}</code>


### PR DESCRIPTION
## Explanation of the issue
Footer included some not really necessary text.
That resulted in forced line breaks with the more narrow layout and on smaller screens.


## Description of your changes
Only keep relevant hints and links.
Displays all version information in one line again (at least on desktop)