### PR TITLE
make pt a string for sure

### DIFF
--- a/backend/import/xml/parser.js
+++ b/backend/import/xml/parser.js
@@ -81,7 +81,7 @@ function parse(content) {
       pt = "",
       side = "a",
       type = "" } = root.version === "3" ? c : c.prop;
-    const [power, toughness] = pt.split("/");
+    const [power, toughness] = String(pt).split("/");
     const fixedColors = getTrueColors(root.version, color, colors);
     const fixedType = getTrueType(type);
     const fixedManaCost = addManaCostBrackets(String(manacost));


### PR DESCRIPTION

## Explanation of the issue
having a pt of something that is not a string in your custom xml will result in an error:
![image](https://user-images.githubusercontent.com/36401181/168454191-5ff8fd10-cdc0-44ff-96d0-efe0ba217123.png)
min example:
```xml
<?xml version="1.0" encoding="UTF-8"?>                                          
<cockatrice_carddatabase version="4">
  <sets>
    <set>
      <name>X</name>
    </set>
  </sets>
  <cards>
    <card>
      <name>TEST CARD PLEASE IGNORE 6</name>
      <set rarity="common">X</set>
      <prop>
        <pt>8</pt>
      </prop>
    </card>
  </cards>
</cockatrice_carddatabase>
```


## Description of your changes
casts pt to a string before using .split
