### PR TITLE
ISSUE-1533: Hide news panel if no message of the day

### DIFF
--- a/frontend/src/lobby/Lobby.jsx
+++ b/frontend/src/lobby/Lobby.jsx
@@ -25,7 +25,7 @@ export default class Lobby extends Component {
           <Header/>
           <GamesPanel roomInfo={roomInfo}/>
           <FileUpload />
-          <NewsPanel motd={STRINGS.PAGE_SECTIONS.MOTD}/>
+          {STRINGS.PAGE_SECTIONS.MOTD && <NewsPanel motd={STRINGS.PAGE_SECTIONS.MOTD}/>}
           {STRINGS.BRANDING.PAYPAL}
           {STRINGS.PAGE_SECTIONS.FOOTER}
           <Version version={serverVersion} MTGJSONVersion={mtgJsonVersion} boosterRulesVersion={boosterRulesVersion}/>


### PR DESCRIPTION
# Summary

Fixes https://github.com/dr4fters/dr4ft/issues/1533.

Hides the News panel if there is no 'message of the day' (a.k.a. 'motd') to display to users.

![image](https://user-images.githubusercontent.com/1089924/171084104-72ef7e29-0b5d-47a7-a598-78f3ebca2481.png)