### PR TITLE
Cleanup old upload hint

### DIFF
--- a/frontend/src/lobby/FileUpload.jsx
+++ b/frontend/src/lobby/FileUpload.jsx
@@ -16,7 +16,7 @@ const FileUpload = () => {
   const [files, setFiles] = useState([]);
   const [errorMsg, setErrorMsg] = useState("");
 
-  // TODO: Custom set uploads have been causing crashes - needs debugging, only allow XML for now
+  // TODO: Custom set uploads in JSON format have been causing crashes (#1432) - needs debugging, only allow XML for now
   // const allowed = ["application/json", "text/xml"]
   // const label = `Drag & Drop your files here, or <span class="filepond--label-action">Browse</span><br/>
   //   JSON (MTGJSON formatted, v4) and XML (Cockatrice formatted, v3 & v4) are supported.`

--- a/frontend/src/lobby/FileUpload.jsx
+++ b/frontend/src/lobby/FileUpload.jsx
@@ -16,6 +16,7 @@ const FileUpload = () => {
   const [files, setFiles] = useState([]);
   const [errorMsg, setErrorMsg] = useState("");
 
+  // TODO: Custom set uploads have been causing crashes - needs debugging, only allow XML for now
   // const allowed = ["application/json", "text/xml"]
   // const label = `Drag & Drop your files here, or <span class="filepond--label-action">Browse</span><br/>
   //   JSON (MTGJSON formatted, v4) and XML (Cockatrice formatted, v3 & v4) are supported.`
@@ -26,13 +27,6 @@ const FileUpload = () => {
   return (
     <fieldset className='fieldset'>
       <legend className='legend'>Upload Custom Set</legend>
-
-      <p>
-        <i className="ion ion-android-alert" style={{ fontSize: 20, paddingRight: 5 }} />
-        Custom set uploads have been causing crashes.
-        While we debug this only XML uploads will be allowed
-      </p>
-
       { allowed.length &&
       <FilePond
         server={{


### PR DESCRIPTION
## Linked tickets
- Issue: #1432
- Temporary workaround from over a year ago: #1453

## Explanation of the issue
The root cause of the initial issue will very likely not be resolved anytime soon.

## Description of your changes
Instead showing a hint in the interface and tell the users that we are working on it (which nobody is), transfer it into a `TODO` note.
We also have the above linked issue tracking the problem in our repo: https://github.com/dr4fters/dr4ft/issues/1432

The UI clearly states what is supported already, no reason to highlight that there used to be something else which is not working anymore (= support for JSON uploads).
