### PR TITLE
add padding to cockatrice hash

### DIFF
--- a/backend/hash.js
+++ b/backend/hash.js
@@ -10,7 +10,7 @@ const opts = {
     },
     digest(digest) {
       // 10 digits of base 16 -> 8 digits of base 32
-      return parseInt(digest.slice(0, 10), 16).toString(32);
+      return parseInt(digest.slice(0, 10), 16).toString(32).padStart(8, "0");
     }
   },
 };


### PR DESCRIPTION
cockatrice hashes are always 8 characters and padded with zeros: https://github.com/Cockatrice/Cockatrice/blob/1c48656623e03e065d21d27a8bdfe1cfcdcaa71c/common/decklist.cpp#L830

